### PR TITLE
Update2: to v3.2.1

### DIFF
--- a/environment/ct3_env.yaml
+++ b/environment/ct3_env.yaml
@@ -22,3 +22,4 @@ dependencies:
   - sed
   - grep
   - samtools
+  - pyarrow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cenotetaker3"
-version = "3.2.0"
+version = "3.2.1"
 authors = [
   { name="Mike Tisza", email="michael.tisza@gmail.com" },
 ]

--- a/src/cenote/cenote_main.sh
+++ b/src/cenote/cenote_main.sh
@@ -9,29 +9,38 @@ PROPHAGE=$4
 CPU=$5
 VERSION=$6
 ANNOTATION_MODE=$7
-TEMPLATE_FILE=$8
-READS=$9
-circ_length_cutoff=${10}
-linear_length_cutoff=${11}
-CIRC_MINIMUM_DOMAINS=${12}
-LIN_MINIMUM_DOMAINS=${13}
-HALL_TYPE=${14}
-C_DBS=${15}
-HMM_DBS=${16}
-WRAP=${17}
-CALLER=${18}
-HHSUITE_TOOL=${19} ##
-ISO_SOURCE=${20}
-COLLECT_DATE=${21}
-META_TYPE=${22}
-SRR=${23}
-SRX=${24}
-BIOSAMP=${25}
-PRJ=${26}
-ASSEMBLER=${27}
-MOL_TYPE=${28}
-DATA_SOURCE=${29}
+C_OUTDIR=$8
+TEMPLATE_FILE=$9
+READS=${10}
+circ_length_cutoff=${11}
+linear_length_cutoff=${12}
+CIRC_MINIMUM_DOMAINS=${13}
+LIN_MINIMUM_DOMAINS=${14}
+HALL_TYPE=${15}
+C_DBS=${16}
+HMM_DBS=${17}
+WRAP=${18}
+CALLER=${19}
+HHSUITE_TOOL=${20}
+ISO_SOURCE=${21}
+COLLECT_DATE=${22}
+META_TYPE=${23}
+SRR=${24}
+SRX=${25}
+BIOSAMP=${26}
+PRJ=${27}
+ASSEMBLER=${28}
+MOL_TYPE=${29}
+DATA_SOURCE=${30}
+GENBANK=${31}
 
+### check output directory (created in cenotetaker3.py)
+
+if [ ! -d $C_OUTDIR ] ; then
+	echo "cannot find output directory $C_OUTDIR"
+	echo "exiting"
+	exit
+fi
 
 ### check HHsuite DBs
 if [ -s ${C_DBS}/hhsearch_DBs/NCBI_CD/NCBI_CD_a3m.ffdata ] ; then
@@ -98,11 +107,11 @@ MDYT=$( date +"%m-%d-%y---%T" )
 echo -e "${BBlack}time update: configuring run directory  ${MDYT}${Color_Off}"
 
 
-if [ ! -d "${run_title}/ct_processing" ]; then
-	mkdir ${run_title}/ct_processing
+if [ ! -d "${C_OUTDIR}/ct_processing" ]; then
+	mkdir -p ${C_OUTDIR}/ct_processing
 fi
 
-TEMP_DIR="${run_title}/ct_processing"
+TEMP_DIR="${C_OUTDIR}/ct_processing"
 
 ### setting universal minimum length
 if [ $circ_length_cutoff -gt $linear_length_cutoff ] ; then
@@ -114,29 +123,30 @@ fi
 
 
 ### save all the parameters in the run_arguments.txt file then print to terminal
-echo "@@@@@@@@@@@@@@@@@@@@@@@@@" >> ${run_title}/run_arguments.txt
-echo "Your specified arguments:" >> ${run_title}/run_arguments.txt
-echo "Cenote-Taker version:              $VERSION" >> ${run_title}/run_arguments.txt
-echo "original contigs:                  $original_contigs" >> ${run_title}/run_arguments.txt
-echo "title of this run:                 $run_title" >> ${run_title}/run_arguments.txt
-echo "Prune prophages?                   $PROPHAGE" >> ${run_title}/run_arguments.txt
-echo "CPUs used for run:                 $CPU" >> ${run_title}/run_arguments.txt
-echo "Annotation only?                   $ANNOTATION_MODE" >> ${run_title}/run_arguments.txt
-echo "minimum circular contig length:    $circ_length_cutoff" >> ${run_title}/run_arguments.txt
-echo "minimum linear contig length:      $linear_length_cutoff" >> ${run_title}/run_arguments.txt
-echo "virus hallmark type(s) to count:   $HALL_TYPE" >> ${run_title}/run_arguments.txt
-echo "min. viral hallmarks for linear:   $LIN_MINIMUM_DOMAINS" >> ${run_title}/run_arguments.txt
-echo "min. viral hallmarks for circular: $CIRC_MINIMUM_DOMAINS" >> ${run_title}/run_arguments.txt
-echo "Wrap contigs?                      $WRAP" >> ${run_title}/run_arguments.txt
-echo "HMM db version                     $HMM_DBS" >> ${run_title}/run_arguments.txt
-echo "ORF Caller:                        $CALLER" >> ${run_title}/run_arguments.txt
-echo "Cenote DBs directory:              $C_DBS" >> ${run_title}/run_arguments.txt
-echo "Cenote scripts directory:          $CENOTE_SCRIPTS" >> ${run_title}/run_arguments.txt
-echo "Template file:                     $TEMPLATE_FILE" >> ${run_title}/run_arguments.txt
-echo "read file(s):                      $READS" >> ${run_title}/run_arguments.txt
-echo "HHsuite tool:                      $HHSUITE_TOOL" >> ${run_title}/run_arguments.txt
+echo "@@@@@@@@@@@@@@@@@@@@@@@@@" >> ${C_OUTDIR}/run_arguments.txt
+echo "Your specified arguments:" >> ${C_OUTDIR}/run_arguments.txt
+echo "Cenote-Taker version:              $VERSION" >> ${C_OUTDIR}/run_arguments.txt
+echo "original contigs:                  $original_contigs" >> ${C_OUTDIR}/run_arguments.txt
+echo "title of this run:                 $run_title" >> ${C_OUTDIR}/run_arguments.txt
+echo "output directory:                  $C_OUTDIR" >>${C_OUTDIR}/run_arguments.txt
+echo "Prune prophages?                   $PROPHAGE" >> ${C_OUTDIR}/run_arguments.txt
+echo "CPUs used for run:                 $CPU" >> ${C_OUTDIR}/run_arguments.txt
+echo "Annotation only?                   $ANNOTATION_MODE" >> ${C_OUTDIR}/run_arguments.txt
+echo "minimum circular contig length:    $circ_length_cutoff" >> ${C_OUTDIR}/run_arguments.txt
+echo "minimum linear contig length:      $linear_length_cutoff" >> ${C_OUTDIR}/run_arguments.txt
+echo "virus hallmark type(s) to count:   $HALL_TYPE" >> ${C_OUTDIR}/run_arguments.txt
+echo "min. viral hallmarks for linear:   $LIN_MINIMUM_DOMAINS" >> ${C_OUTDIR}/run_arguments.txt
+echo "min. viral hallmarks for circular: $CIRC_MINIMUM_DOMAINS" >> ${C_OUTDIR}/run_arguments.txt
+echo "Wrap contigs?                      $WRAP" >> ${C_OUTDIR}/run_arguments.txt
+echo "HMM db version                     $HMM_DBS" >> ${C_OUTDIR}/run_arguments.txt
+echo "ORF Caller:                        $CALLER" >> ${C_OUTDIR}/run_arguments.txt
+echo "Cenote DBs directory:              $C_DBS" >> ${C_OUTDIR}/run_arguments.txt
+echo "Cenote scripts directory:          $CENOTE_SCRIPTS" >> ${C_OUTDIR}/run_arguments.txt
+echo "Template file:                     $TEMPLATE_FILE" >> ${C_OUTDIR}/run_arguments.txt
+echo "read file(s):                      $READS" >> ${C_OUTDIR}/run_arguments.txt
+echo "HHsuite tool:                      $HHSUITE_TOOL" >> ${C_OUTDIR}/run_arguments.txt
 
-cat ${run_title}/run_arguments.txt
+cat ${C_OUTDIR}/run_arguments.txt
 
 echo " "
 
@@ -145,13 +155,13 @@ echo " "
 #- input:
 #-- ${original_contigs}
 #- output:
-#-- ${run_title}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta
+#-- ${C_OUTDIR}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta
 
 if [ -s ${original_contigs} ] ; then
 	
 	seqkit seq --quiet -g -m $LENGTH_MINIMUM $original_contigs |\
 	  seqkit replace --quiet -p '^' -r ${run_title}_{nr}@#@# |\
-	  sed 's/@#@#/ /g' > ${run_title}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta
+	  sed 's/@#@#/ /g' > ${C_OUTDIR}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta
 
 else
 	echo "${original_contigs} not found"
@@ -161,31 +171,31 @@ fi
 
 ### split contigs into equal parts for prodigal ORF calling, call ORFs
 #- input:
-#-- ${run_title}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta
+#-- ${C_OUTDIR}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta
 #- output:
 #-- ${TEMP_DIR}/contig_name_map.tsv
 #-- ${TEMP_DIR}/ORF_orig_contigs/split/*.faa (1 or more)
 
-if [ -s ${run_title}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta ] ; then
+if [ -s ${C_OUTDIR}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta ] ; then
 	if [ ! -d "${TEMP_DIR}/ORF_orig_contigs" ]; then
 		mkdir ${TEMP_DIR}/ORF_orig_contigs
 	fi
 
 	# table with ct name and input name in separate columns
 	TABQ=$'\t'
-	grep -F ">" ${run_title}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta |\
+	grep -F ">" ${C_OUTDIR}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta |\
 	  sed "s/ /\t/" | sed 's/>//g' > ${TEMP_DIR}/contig_name_map.tsv
 
 	MDYT=$( date +"%m-%d-%y---%T" )
 	echo -e "${BRed}time update: running pyrodigal on all contigs  ${MDYT}${Color_Off}"
 
-	python ${CENOTE_SCRIPTS}/python_modules/pyrodigal_gv_runner.py ${run_title}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta\
+	python ${CENOTE_SCRIPTS}/python_modules/pyrodigal_gv_runner.py ${C_OUTDIR}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta\
 	  ${TEMP_DIR}/ORF_orig_contigs $CPU $CALLER
 
 	seqkit split --quiet -j $CPU -p $CPU -O ${TEMP_DIR}/ORF_orig_contigs/split ${TEMP_DIR}/ORF_orig_contigs/pyrodigal_gv_AAs.prod.faa
 
 else
-	echo "couldn't find ${run_title}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta"
+	echo "couldn't find ${C_OUTDIR}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta"
 	echo "exiting"
 	exit
 fi
@@ -244,7 +254,7 @@ fi
 ### grabbing contigs with minimum marker gene number
 #- input: -#
 #-- ${TEMP_DIR}/contigs_to_keep.txt
-#-- ${run_title}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta
+#-- ${C_OUTDIR}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta
 #- output: -#
 #-- ${TEMP_DIR}/unprocessed_hallmark_contigs.fasta
 
@@ -258,7 +268,7 @@ if [ -s ${TEMP_DIR}/contigs_to_keep.txt ] ; then
 	if [ $KEEP_COUNT -ge 1 ] ; then
 
 		seqkit grep --quiet -f ${TEMP_DIR}/contigs_to_keep.txt\
-		  ${run_title}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta > ${TEMP_DIR}/unprocessed_hallmark_contigs.fasta
+		  ${C_OUTDIR}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta > ${TEMP_DIR}/unprocessed_hallmark_contigs.fasta
 
 	else
 		echo "no contigs with ${KEEP_COUNT} hallmark gene(s) were detected. Exiting."
@@ -1138,7 +1148,8 @@ fi
 #--  ${TEMP_DIR}/hallmark_tax/phanotate_seqs1.txt
 #--  ${TEMP_DIR}/reORF/contig_gcodes1.txt
 #- output: -#
-#--  ${run_title}/sequin_and_genome_maps/*.fsa (1 or more)
+#--  ${C_OUTDIR}/sequin_and_genome_maps/*.fsa (1 or more)
+#--  ${TEMP_DIR}/contig_to_organism.tsv
 
 if [ -s ${TEMP_DIR}/oriented_hallmark_contigs.pruned.fasta ] &&\
    [ -s ${TEMP_DIR}/final_taxonomy/virus_taxonomy_summary.tsv ] &&\
@@ -1149,9 +1160,9 @@ if [ -s ${TEMP_DIR}/oriented_hallmark_contigs.pruned.fasta ] &&\
 
 	python ${CENOTE_SCRIPTS}/python_modules/make_sequin_fsas.py ${TEMP_DIR}/oriented_hallmark_contigs.pruned.fasta\
 	  ${TEMP_DIR}/final_taxonomy/virus_taxonomy_summary.tsv\
-	  ${TEMP_DIR}/threshold_contigs_terminal_repeat_summary.tsv ${TEMP_DIR} ${run_title}/sequin_and_genome_maps\
+	  ${TEMP_DIR}/threshold_contigs_terminal_repeat_summary.tsv ${TEMP_DIR} ${C_OUTDIR}/sequin_and_genome_maps\
 	  ${TEMP_DIR}/hallmark_tax/phanotate_seqs1.txt ${TEMP_DIR}/reORF/contig_gcodes1.txt $ISO_SOURCE\
-	  $COLLECT_DATE $META_TYPE $SRR $SRX $BIOSAMP $PRJ $MOL_TYPE $DATA_SOURCE
+	  $COLLECT_DATE $META_TYPE $SRR $SRX $BIOSAMP $PRJ $MOL_TYPE $DATA_SOURCE $GENBANK
 
 else
 
@@ -1165,9 +1176,9 @@ fi
 #--  ${TEMP_DIR}/phrogs_pyhmmer/pyhmmer_report_AAs.tsv
 #--  ${TEMP_DIR}/hhpred/hhpred_report_AAs.tsv
 #- output: -#
-#--  ${run_title}/sequin_and_genome_maps/*.tbl
-#--  ${run_title}/final_ORF_list.txt
-#--  ${run_title}/final_genes_to_contigs_annotation_summary.tsv
+#--  ${C_OUTDIR}/sequin_and_genome_maps/*.tbl
+#--  ${C_OUTDIR}/final_ORF_list.txt
+#--  ${C_OUTDIR}/final_genes_to_contigs_annotation_summary.tsv
 
 
 if [ -s ${TEMP_DIR}/contig_gene_annotation_summary.pruned.tsv ] ; then
@@ -1176,7 +1187,7 @@ if [ -s ${TEMP_DIR}/contig_gene_annotation_summary.pruned.tsv ] ; then
 	## sequin tbl
 	python ${CENOTE_SCRIPTS}/python_modules/make_sequin_tbls.py ${TEMP_DIR}/contig_gene_annotation_summary.pruned.tsv\
 	  ${TEMP_DIR}/oriented_hallmark_contigs.pruned.tRNAscan.tsv ${TEMP_DIR}/phrogs_pyhmmer/pyhmmer_report_AAs.tsv\
-	  ${TEMP_DIR}/hhpred/hhpred_report_AAs.tsv ${run_title}/sequin_and_genome_maps
+	  ${TEMP_DIR}/hhpred/hhpred_report_AAs.tsv ${C_OUTDIR}/sequin_and_genome_maps $GENBANK
 
 else
 	echo "couldn't find annotation file for tbl generation"
@@ -1185,14 +1196,14 @@ fi
 
 ### Make sequin-formatted comment (cmt) file
 #- input: -#
-#--  ${run_title}/sequin_and_genome_maps/*.fsa
+#--  ${C_OUTDIR}/sequin_and_genome_maps/*.fsa
 #--  ${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv
 #- output: -#
-#--  ${run_title}/sequin_and_genome_maps/*.cmt
+#--  ${C_OUTDIR}/sequin_and_genome_maps/*.cmt
 
-FSA_FILES=$( find ${run_title}/sequin_and_genome_maps -type f -name "*fsa" )
+FSA_FILES=$( find ${C_OUTDIR}/sequin_and_genome_maps -type f -name "*fsa" )
 
-if [ -n "$FSA_FILES" ] ; then
+if [ -n "$FSA_FILES" ] && [ "$GENBANK" == "True" ] ; then
 	for REC in $FSA_FILES ; do
 		if [ -s ${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv ] ; then
 			COVERAGE=$( awk -v SEQNAME="${REC%.fsa}" '{OFS=FS="\t"}{ if ($1 == SEQNAME) {print $7}}' \
@@ -1215,10 +1226,10 @@ fi
 #- input: -#
 #--  ${TEMP_DIR}/oriented_hallmark_contigs.pruned.fasta
 #- output: -#
-#--  ${run_title}/${run_title}_virus_sequences.fna
+#--  ${C_OUTDIR}/${run_title}_virus_sequences.fna
 
 if [ -s ${TEMP_DIR}/oriented_hallmark_contigs.pruned.fasta ] ; then
-	seqkit replace --quiet -p "\s.+" ${TEMP_DIR}/oriented_hallmark_contigs.pruned.fasta > ${run_title}/${run_title}_virus_sequences.fna
+	seqkit replace --quiet -p "\s.+" ${TEMP_DIR}/oriented_hallmark_contigs.pruned.fasta > ${C_OUTDIR}/${run_title}_virus_sequences.fna
 
 else
 	echo "couldn't find file for final virus seqs"
@@ -1226,75 +1237,73 @@ fi
 
 ### Merge final translated ORFs
 #- input: -#
-#--  ${run_title}/final_ORF_list.txt
+#--  ${C_OUTDIR}/final_ORF_list.txt
 #--  ${TEMP_DIR}/reORF/reORFcalled_all.faa
 #- output: -#
-#--  ${run_title}/${run_title}_virus_AA.faa
+#--  ${C_OUTDIR}/${run_title}_virus_AA.faa
 
-if [ -s ${run_title}/final_ORF_list.txt ] ; then
-	seqkit grep --quiet -f ${run_title}/final_ORF_list.txt\
-	  ${TEMP_DIR}/reORF/reORFcalled_all.faa | seqkit replace --quiet -p "\s.+" > ${run_title}/${run_title}_virus_AA.faa
+if [ -s ${C_OUTDIR}/final_ORF_list.txt ] ; then
+	seqkit grep --quiet -f ${C_OUTDIR}/final_ORF_list.txt\
+	  ${TEMP_DIR}/reORF/reORFcalled_all.faa | seqkit replace --quiet -p "\s.+" > ${C_OUTDIR}/${run_title}_virus_AA.faa
 
-	rm ${run_title}/final_ORF_list.txt
+	rm ${C_OUTDIR}/final_ORF_list.txt
 else
 	echo "couldn't find list of final ORFs"
 fi
 
 ### Run tbl2asn
 #- input: -#
-#--  ${run_title}/sequin_and_genome_maps/*.fsa
-#--  ${run_title}/sequin_and_genome_maps/*.tbl
-#--  ${run_title}/sequin_and_genome_maps/*.cmt
+#--  ${C_OUTDIR}/sequin_and_genome_maps/*.fsa
+#--  ${C_OUTDIR}/sequin_and_genome_maps/*.tbl
+#--  ${C_OUTDIR}/sequin_and_genome_maps/*.cmt
 #- output: -#
-#--  ${run_title}/sequin_and_genome_maps/*.gbf
-#--  ${run_title}/sequin_and_genome_maps/*.sqn
-#--  ${run_title}/sequin_and_genome_maps/*.val
+#--  ${C_OUTDIR}/sequin_and_genome_maps/*.gbf
+#--  ${C_OUTDIR}/sequin_and_genome_maps/*.sqn
+#--  ${C_OUTDIR}/sequin_and_genome_maps/*.val
 
-if [ -s ${TEMPLATE_FILE} ] ; then
-	tbl2asn -V vb -t ${TEMPLATE_FILE} -X C -p ${run_title}/sequin_and_genome_maps >\
-	  ${run_title}/sequin_and_genome_maps/tbl2asn.log 2>&1
+if [ -s ${TEMPLATE_FILE} ] && [ "$GENBANK" == "True" ] ; then
+	tbl2asn -V vb -t ${TEMPLATE_FILE} -X C -p ${C_OUTDIR}/sequin_and_genome_maps >\
+	  ${C_OUTDIR}/sequin_and_genome_maps/tbl2asn.log 2>&1
 else
 	echo "could not find template file for tbl2asn"
 fi
 
 ### Make run summary files
 #- input: -#
-#--  ${run_title}/final_genes_to_contigs_annotation_summary.tsv
+#--  ${C_OUTDIR}/final_genes_to_contigs_annotation_summary.tsv
 #--  ${TEMP_DIR}/contig_name_map.tsv
 #--  ${TEMP_DIR}/final_taxonomy/virus_taxonomy_summary.tsv
-#--  ${run_title}/sequin_and_genome_maps/*.fsa
 #--  ${TEMP_DIR}/reORF/contig_gcodes1.txt
 #--  ${TEMP_DIR}/hallmark_tax/phanotate_seqs1.txt
+#--  ${TEMP_DIR}/contig_to_organism.tsv
 #- output: -#
-#--  ${run_title}/${run_title}_virus_summary.tsv
+#--  ${C_OUTDIR}/${run_title}_virus_summary.tsv
 #----	fields
 #----	(contig	input_name	organism	virus_seq_length	end_feature	gene_count	virion_hallmark_count
 #----	 rep_hallmark_count	virion_hallmark_genes	rep_hallmark_genes	taxonomy_hierarchy	ORF_caller)
-#--  ${run_title}/${run_title}_prune_summary.tsv
+#--  ${C_OUTDIR}/${run_title}_prune_summary.tsv
 #----	fields
 #----	(contig	contig_length	chunk_length	chunk_name	chunk_start	chunk_stop)
 
-if [ -s ${run_title}/final_genes_to_contigs_annotation_summary.tsv ] ; then
+if [ -s ${C_OUTDIR}/final_genes_to_contigs_annotation_summary.tsv ] ; then
 	MDYT=$( date +"%m-%d-%y---%T" )
 	echo -e "${BYellow}time update: Making virus summary table ${MDYT}${Color_Off}"
 
 	python ${CENOTE_SCRIPTS}/python_modules/virus_summary.py ${TEMP_DIR}/contig_name_map.tsv \
-	  ${run_title}/final_genes_to_contigs_annotation_summary.tsv ${TEMP_DIR}/final_taxonomy/virus_taxonomy_summary.tsv \
-	  ${run_title}/sequin_and_genome_maps ${run_title} ${TEMP_DIR}/reORF/contig_gcodes1.txt\
-	  ${TEMP_DIR}/hallmark_tax/phanotate_seqs1.txt $CALLER
+	  ${C_OUTDIR}/final_genes_to_contigs_annotation_summary.tsv ${TEMP_DIR}/final_taxonomy/virus_taxonomy_summary.tsv \
+	  ${C_OUTDIR} ${run_title} ${TEMP_DIR}/reORF/contig_gcodes1.txt\
+	  ${TEMP_DIR}/hallmark_tax/phanotate_seqs1.txt $CALLER ${TEMP_DIR}/contig_to_organism.tsv
 
 	python ${CENOTE_SCRIPTS}/python_modules/summary_statement.py\
-	  ${run_title}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta $LENGTH_MINIMUM\
-	  ${run_title}/${run_title}_virus_summary.tsv ${run_title}/${run_title}_prune_summary.tsv\
-	  ${run_title}/final_genes_to_contigs_annotation_summary.tsv $ANNOTATION_MODE
+	  ${C_OUTDIR}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta $LENGTH_MINIMUM\
+	  ${C_OUTDIR}/${run_title}_virus_summary.tsv ${C_OUTDIR}/${run_title}_prune_summary.tsv\
+	  ${C_OUTDIR}/final_genes_to_contigs_annotation_summary.tsv $ANNOTATION_MODE $PROPHAGE
 
 else
 	echo "couldn't find files to make run summary"
 
 fi
 
-
-# gtf/gff
 
 MDYT=$( date +"%m-%d-%y---%T" )
 echo -e "${BYellow}Cenote-Taker finishing now ${MDYT}${Color_Off}"

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -118,7 +118,8 @@ def cenotetaker3():
                             help='Default: False -- Annotate sequences only (skip discovery). Only use if you believe \
                                 each provided sequence is viral')
     optional_args.add_argument("-wd", "--working_directory", dest="c_workdir", type=str, default=Def_workdir, 
-                            help=f"Default: {Def_workdir} -- Set working directory. run directory will be created within.")
+                            help=f"Default: {Def_workdir} -- Set working directory with absolute or relative path. \
+                                run directory will be created within.")
     optional_args.add_argument("--template_file", dest="template_file", type=str, 
                             default=str(cenote_script_path) + '/dummy_template.sbt', 
                             help='Template file with some metadata. Real one required for GenBank submission. Takes a \

--- a/src/cenote/get_ct3_databases.py
+++ b/src/cenote/get_ct3_databases.py
@@ -117,39 +117,39 @@ def get_ct3_dbs():
 
     if str(args.HHCDD) == "True":
         print ("running hhsuite CDD database update/install")
-        subprocess.call(['rm', '-r', '-f', str(args.C_DBS) + '/NCBI_CD/'])
-        isExist = os.path.exists(str(args.C_DBS) + '/NCBI_CD')
+        subprocess.call(['rm', '-r', '-f', str(args.C_DBS) + '/hhsearch_DBs/NCBI_CD/'])
+        isExist = os.path.exists(str(args.C_DBS) + '/hhsearch_DBs/NCBI_CD')
         if not isExist:
-            os.makedirs(str(args.C_DBS) + '/NCBI_CD/', exist_ok=True)
-        subprocess.call(['wget', '--directory-prefix=' + str(args.C_DBS), 
+            os.makedirs(str(args.C_DBS) + '/hhsearch_DBs/NCBI_CD/', exist_ok=True)
+        subprocess.call(['wget', '--directory-prefix=' + str(args.C_DBS) + '/hhsearch_DBs', 
                          'https://zenodo.org/records/3660537/files/NCBI_CD_hhsuite.tgz'])
-        subprocess.call(['tar', '-xvf', f'{str(args.C_DBS)}/NCBI_CD_hhsuite.tgz', 
-                         '--directory', str(args.C_DBS)])
-        subprocess.call(['rm', '-f', f'{str(args.C_DBS)}/NCBI_CD_hhsuite.tgz'])
+        subprocess.call(['tar', '-xvf', f'{str(args.C_DBS)}/hhsearch_DBs/NCBI_CD_hhsuite.tgz', 
+                         '--directory', str(args.C_DBS) + '/hhsearch_DBs'])
+        subprocess.call(['rm', '-f', f'{str(args.C_DBS)}/hhsearch_DBs/NCBI_CD_hhsuite.tgz'])
 
     if str(args.HHPFAM) == "True":
         print ("running PFAM database update/install")
-        subprocess.call(['rm', '-r', '-f', str(args.C_DBS) + '/pfam_32_db/'])
-        isExist = os.path.exists(str(args.C_DBS) + '/pfam_32_db')
+        subprocess.call(['rm', '-r', '-f', str(args.C_DBS) + '/hhsearch_DBs/pfam_32_db/'])
+        isExist = os.path.exists(str(args.C_DBS) + '/hhsearch_DBs/pfam_32_db')
         if not isExist:
-            os.makedirs(str(args.C_DBS) + '/pfam_32_db/', exist_ok=True)
-        subprocess.call(['wget', '--directory-prefix=' + str(args.C_DBS), 
+            os.makedirs(str(args.C_DBS) + '/hhsearch_DBs/pfam_32_db/', exist_ok=True)
+        subprocess.call(['wget', '--directory-prefix=' + str(args.C_DBS) + '/hhsearch_DBs', 
                          'http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/pfamA_32.0.tar.gz'])
-        subprocess.call(['tar', '-xvf', f'{str(args.C_DBS)}/pfamA_32.0.tar.gz', 
-                         '--directory', str(args.C_DBS) + '/pfam_32_db'])
-        subprocess.call(['rm', '-f', f'{str(args.C_DBS)}/pfamA_32.0.tar.gz'])
+        subprocess.call(['tar', '-xvf', f'{str(args.C_DBS)}/hhsearch_DBs/pfamA_32.0.tar.gz', 
+                         '--directory', str(args.C_DBS) + '/hhsearch_DBs/pfam_32_db'])
+        subprocess.call(['rm', '-f', f'{str(args.C_DBS)}/hhsearch_DBs/pfamA_32.0.tar.gz'])
 
     if str(args.HHPDB) == "True":
         print ("running PDB database update/install. This could take around 2 hours.")
-        subprocess.call(['rm', '-r', '-f', str(args.C_DBS) + '/pdb70/'])
-        isExist = os.path.exists(str(args.C_DBS) + '/pdb70')
+        subprocess.call(['rm', '-r', '-f', str(args.C_DBS) + '/hhsearch_DBs/pdb70/'])
+        isExist = os.path.exists(str(args.C_DBS) + '/hhsearch_DBs/pdb70')
         if not isExist:
-            os.makedirs(str(args.C_DBS) + '/pdb70/', exist_ok=True)
-        subprocess.call(['wget', '--directory-prefix=' + str(args.C_DBS), 
+            os.makedirs(str(args.C_DBS) + '/hhsearch_DBs/pdb70/', exist_ok=True)
+        subprocess.call(['wget', '--directory-prefix=' + str(args.C_DBS) + '/hhsearch_DBs', 
                          'http://wwwuser.gwdg.de/~compbiol/data/hhsuite/databases/hhsuite_dbs/pdb70_from_mmcif_latest.tar.gz'])
-        subprocess.call(['tar', '-xvf', f'{str(args.C_DBS)}/pdb70_from_mmcif_latest.tar.gz', 
-                         '--directory', str(args.C_DBS) + '/pdb70'])
-        subprocess.call(['rm', '-f', f'{str(args.C_DBS)}/pdb70_from_mmcif_latest.tar.gz'])
+        subprocess.call(['tar', '-xvf', f'{str(args.C_DBS)}/hhsearch_DBs/pdb70_from_mmcif_latest.tar.gz', 
+                         '--directory', str(args.C_DBS) + '/hhsearch_DBs/pdb70'])
+        subprocess.call(['rm', '-f', f'{str(args.C_DBS)}/hhsearch_DBs/pdb70_from_mmcif_latest.tar.gz'])
 
 if __name__ == "__main__":
     get_ct3_dbs()

--- a/src/cenote/python_modules/combine_hallmark_counts.py
+++ b/src/cenote/python_modules/combine_hallmark_counts.py
@@ -63,7 +63,7 @@ names_dt = pd.read_csv(names_file, sep = "\t", names=['contig', 'original_name']
 
 merge_dt = pd.merge(hits_dt, names_dt, on = 'contig', how = 'outer')
 
-merge_dt = merge_dt.fillna(0)
+merge_dt = merge_dt.infer_objects(copy=False).fillna(0)
 
 
 

--- a/src/cenote/python_modules/hhpred_to_table.py
+++ b/src/cenote/python_modules/hhpred_to_table.py
@@ -32,8 +32,20 @@ for hhresult_file in hhrout_list:
             #with this logic, only files with results (lines starting with >) append the df
             if line.startswith('>'):
                 full_desc = line.rstrip('\n').strip('>')
-                accession = full_desc.split(' ; ')[0]
-                annotation = full_desc.split(' ; ')[2]
+                if line.startswith('>cd') or line.startswith('>sd'):
+                    accession = full_desc.split(' ')[0]
+
+                    try:
+                        annotation = full_desc.split('; ')[1].split('. ')[0]
+                    except:
+                        annotation = 'hypothetical protein'
+                else:
+                    accession = full_desc.split(' ; ')[0]
+
+                    try:
+                        annotation = full_desc.split('; ')[2]
+                    except:
+                        annotation = 'hypothetical protein'
 
                 full_stats = next(hrh, '').strip()
                 probability = full_stats.split('  ')[0].split('=')[1]

--- a/src/cenote/python_modules/hhpred_to_table.py
+++ b/src/cenote/python_modules/hhpred_to_table.py
@@ -32,18 +32,37 @@ for hhresult_file in hhrout_list:
             #with this logic, only files with results (lines starting with >) append the df
             if line.startswith('>'):
                 full_desc = line.rstrip('\n').strip('>')
+
+                ## CDD models
                 if line.startswith('>cd') or line.startswith('>sd'):
                     accession = full_desc.split(' ')[0]
 
                     try:
-                        annotation = full_desc.split('; ')[1].split('. ')[0]
+                        #annotation = full_desc.split('; ')[1].split('. ')[0]
+                        annotation = full_desc.split(' ')[1].split(';')[0]
                     except:
                         annotation = 'hypothetical protein'
-                else:
+
+                ## PFAM models
+                elif line.startswith('>PF'):
                     accession = full_desc.split(' ; ')[0]
 
                     try:
                         annotation = full_desc.split('; ')[2]
+                    except:
+                        annotation = 'hypothetical protein'
+
+                ## PDB models
+                else:
+                    accession = full_desc.split(' ')[0]
+
+                    try:
+                        annotationpd = full_desc.split(' ')[1:]
+                        annotationpd = ' '.join(annotationpd)
+                        if ']' in annotationpd:
+                            annotation = annotationpd.split(']')[1].split(';')[0]
+                        else:
+                            annotation = annotationpd.split(';')[0]
                     except:
                         annotation = 'hypothetical protein'
 

--- a/src/cenote/python_modules/make_sequin_tbls.py
+++ b/src/cenote/python_modules/make_sequin_tbls.py
@@ -18,13 +18,15 @@ hhpred_table = sys.argv[4]
 
 out_dir = sys.argv[5]
 
+GENBANK = sys.argv[6]
+
 if not os.path.isdir(out_dir):
     os.makedirs(out_dir)
 
 # load gene/contig table
 gene_contig_df = pd.read_csv(gene_contig_file, sep = "\t")
 
-gene_contig_df['chunk_name'] = gene_contig_df['chunk_name'].fillna("NaN")
+gene_contig_df['chunk_name'] = gene_contig_df['chunk_name'].infer_objects(copy=False).fillna("NaN")
 
 ## quick_df is for adding chunk info to trnascan table via merge
 quick_df = gene_contig_df[['contig', 'chunk_name', 'chunk_length', 
@@ -68,8 +70,8 @@ if  os.path.isfile(tRNA_table) and os.path.getsize(tRNA_table) > 0:
     tRNA_df = tRNA_df[['contig', 'chunk_name', 'gene_start', 'gene_stop', 'gene_name', 
                     'gene_orient', 'evidence_description', 'evidence_acession', 'Evidence_source']]
     
-    tRNA_df['chunk_name'] = tRNA_df['chunk_name'].fillna("NaN")
-    quick_df['chunk_name'] = quick_df['chunk_name'].fillna("NaN")
+    tRNA_df['chunk_name'] = tRNA_df['chunk_name'].infer_objects(copy=False).fillna("NaN")
+    quick_df['chunk_name'] = quick_df['chunk_name'].infer_objects(copy=False).fillna("NaN")
 
     tRNA_plus_df = pd.merge(tRNA_df, quick_df, on = ["contig", "chunk_name"], how = "left")
 
@@ -173,7 +175,7 @@ ORF_df.to_csv(ORF_list_out, sep = "\t", index = False, header = False)
 
 
 ## need a chunk value for all viruses to properly group
-merged_df['chunk_name'] = merged_df['chunk_name'].fillna("NaN")
+merged_df['chunk_name'] = merged_df['chunk_name'].infer_objects(copy=False).fillna("NaN")
 
 chunk_grouped_df = merged_df.groupby(['contig', 'chunk_name'], dropna = False)
 
@@ -185,7 +187,12 @@ def tbl_first_second(gstart, gstop, gorient):
     else:
         return gstop, gstart, gorient
 
+
+if GENBANK == 'False':
+    sys.exit()
+
 #### loop each virus 
+
 for name, seq_group in chunk_grouped_df:
 
     # header line for tbl

--- a/src/cenote/python_modules/summary_statement.py
+++ b/src/cenote/python_modules/summary_statement.py
@@ -14,6 +14,7 @@ vir_sum = sys.argv[3]
 prune_sum = sys.argv[4]
 genes_sum = sys.argv[5]
 ann_mode = sys.argv[6]
+prune = sys.argv[7]
 
 ###
 
@@ -50,6 +51,8 @@ else:
             f'searched and {pc}{num_virus_contigs}{lc} viruses were detected and annotated.{endc}')
       print(f'>>> {lc}In all, {pc}{nonhypo_genes / all_genes:.0%}{lc} of '
             f'virus genes were annotated with functional information.{endc}')
-      print(f'>>> {pc}{over_10kb}{lc} contig(s) over 10kb went through pruning module '
-            f'and {pc}{pruned_seqs}{lc} were shortened by pruning.{endc}')
+      if prune == 'True':
+            print(f'>>> {pc}{over_10kb}{lc} contig(s) over 10kb went through pruning module '
+                  f'and {pc}{pruned_seqs}{lc} were shortened by pruning.{endc}')
+
 print('')

--- a/src/cenote/python_modules/vote_taxonomy.py
+++ b/src/cenote/python_modules/vote_taxonomy.py
@@ -139,7 +139,8 @@ def taxon_decider(name, group, taxonomy_list):
                                      group['taxlineage'].apply(lambda st: st[:st.find(taxonomy)+len(taxonomy)]), 
                                      taxonomy)
     
-        lineage_to_tax = lineage_to_tax_S[0]
+        #lineage_to_tax = lineage_to_tax_S[0]
+        lineage_to_tax = pd.Series(lineage_to_tax_S).agg(pd.Series.mode)[0]
     except:
         lineage_to_tax = "NA"
     

--- a/src/cenote/python_modules/vote_taxonomy.py
+++ b/src/cenote/python_modules/vote_taxonomy.py
@@ -135,7 +135,7 @@ def taxon_decider(name, group, taxonomy_list):
 
         
     try:
-        lineage_to_tax_S = np.where(group['taxlineage'].str.contains(taxonomy), 
+        lineage_to_tax_S = np.where(group['taxlineage'].str.contains(f'_{taxonomy}'), 
                                      group['taxlineage'].apply(lambda st: st[:st.find(taxonomy)+len(taxonomy)]), 
                                      taxonomy)
     


### PR DESCRIPTION
Changes:

1) Added `-wd`/`--working_directory` flags for specifying working directory for outputs
2) Added pyarrow to enviroment files. Prevents pandas futurewarning.
3) Fixed downcasting in `fillna()` commands in python/pandas
4) Fixed paths so that hhsuite databases are download and referred to correctly
5) Added `--genbank` flag which allows users to disable genbank outputs
6) Fixed taxonomy lineage parsing in `vote_taxonomy.py` in certain cases.
7) Fixed `hhpred_to_table.py` parsing of hhsuite output files to correctly hand CDD and PDB accessions/descriptions.
9) Updated scripts so that in annotation mode `-am True` (unless flag `--caller adaptive`) to skip unnecessary initial `pyhmmer` steps. This reduced runtime by about 25%. 