### PR TITLE
Update3 (v3.3.0 updates)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.Rhistory
+
 blast_DBs/
 cdd_rps_db/
 hmmscan_DBs/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Image of example genome map:
 
 **Most recent versions**
 
-Cenote-Taker 3 scripts:   `v3.2.1`
+Cenote-Taker 3 scripts:   `v3.3.0`
 Cenote-Taker 3 Databases: `v3.1.1`
 
 **This should work on MacOS and Linux**

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ conda 23.7.4
 
 `cd ..`
 
-`get_ct3_dbs -o ct3_DBs --hmm T --mmseqs_tax T --mmseqs_cdd T --domain_list T`
+`get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --mmseqs_cdd T --domain_list T`
 
 <details>
 
@@ -107,7 +107,7 @@ conda 23.7.4
   | pdb70    | 56 GB  |
   
   ```         
-  get_ct3_dbs -o ct3_DBs --hmm T --mmseqs_tax T --mmseqs_cdd T --domain_list T --hhCDD T --hhPFAM T --hhPDB T
+  get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --mmseqs_cdd T --domain_list T --hhCDD T --hhPFAM T --hhPDB T
   ```
 
 </details>
@@ -142,7 +142,7 @@ conda 23.7.4
 
 `cd ..`
 
-`get_ct3_dbs -o ct3_DBs --hmm T --mmseqs_tax T --mmseqs_cdd T --domain_list T`
+`get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --mmseqs_cdd T --domain_list T`
 
 <details>
 
@@ -161,7 +161,7 @@ conda 23.7.4
   | pdb70    | 56 GB  |
   
   ```         
-  get_ct3_dbs -o ct3_DBs --hmm T --mmseqs_tax T --mmseqs_cdd T --domain_list T --hhCDD T --hhPFAM T --hhPDB T
+  get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --mmseqs_cdd T --domain_list T --hhCDD T --hhPFAM T --hhPDB T
   ```
 
 </details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cenotetaker3"
-version = "3.2.1"
+version = "3.3.0"
 authors = [
   { name="Mike Tisza", email="michael.tisza@gmail.com" },
 ]

--- a/src/cenote/cenote_main.sh
+++ b/src/cenote/cenote_main.sh
@@ -147,6 +147,8 @@ echo "Cenote scripts directory:          $CENOTE_SCRIPTS" >> ${C_OUTDIR}/run_arg
 echo "Template file:                     $TEMPLATE_FILE" >> ${C_OUTDIR}/run_arguments.txt
 echo "read file(s):                      $READS" >> ${C_OUTDIR}/run_arguments.txt
 echo "HHsuite tool:                      $HHSUITE_TOOL" >> ${C_OUTDIR}/run_arguments.txt
+echo "Taxonomy DB:                       $TAXDBV" >> ${C_OUTDIR}/run_arguments.txt
+
 
 cat ${C_OUTDIR}/run_arguments.txt
 
@@ -1232,22 +1234,7 @@ if [ -n "$FSA_FILES" ] && [ "$GENBANK" == "True" ] ; then
 	  ${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv\
 	  ${C_OUTDIR}/sequin_and_genome_maps\
 	  $ASSEMBLER $SEQTECH
-#	for REC in $FSA_FILES ; do
-#		if [ -s ${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv ] ; then
-#			COVERAGE=$( awk -v SEQNAME="${REC%.fsa}" '{OFS=FS="\t"}{ if ($1 == SEQNAME) {print $7}}' \
-#				${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv | head -n1 )
-#
-#		else
-#			COVERAGE=1
-#		fi
-#
-#		echo "StructuredCommentPrefix	##Genome-Assembly-Data-START##" > ${REC%.fsa}.cmt
-#		echo "Assembly Method	${ASSEMBLER}" >> ${REC%.fsa}.cmt
-#		echo "Genome Coverage	"$COVERAGE"x" >> ${REC%.fsa}.cmt
-#		echo "Sequencing Technology	Illumina" >> ${REC%.fsa}.cmt
-#		echo "Annotation Pipeline	Cenote-Taker 3" >> ${REC%.fsa}.cmt
-#		echo "URL	https://github.com/mtisza1/Cenote-Taker3" >> ${REC%.fsa}.cmt	
-#	done
+
 fi
 
 ### Merge final virus seqs

--- a/src/cenote/cenote_main.sh
+++ b/src/cenote/cenote_main.sh
@@ -34,6 +34,7 @@ MOL_TYPE=${29}
 DATA_SOURCE=${30}
 GENBANK=${31}
 TAXDBV=${32}
+SEQTECH=${33}
 
 ### check output directory (created in cenotetaker3.py)
 
@@ -1226,22 +1227,27 @@ fi
 FSA_FILES=$( find ${C_OUTDIR}/sequin_and_genome_maps -type f -name "*fsa" )
 
 if [ -n "$FSA_FILES" ] && [ "$GENBANK" == "True" ] ; then
-	for REC in $FSA_FILES ; do
-		if [ -s ${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv ] ; then
-			COVERAGE=$( awk -v SEQNAME="${REC%.fsa}" '{OFS=FS="\t"}{ if ($1 == SEQNAME) {print $7}}' \
-				${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv | head -n1 )
 
-		else
-			COVERAGE=1
-		fi
-
-		echo "StructuredCommentPrefix	##Genome-Assembly-Data-START##" > ${REC%.fsa}.cmt
-		echo "Assembly Method	${ASSEMBLER}" >> ${REC%.fsa}.cmt
-		echo "Genome Coverage	"$COVERAGE"x" >> ${REC%.fsa}.cmt
-		echo "Sequencing Technology	Illumina" >> ${REC%.fsa}.cmt
-		echo "Annotation Pipeline	Cenote-Taker 3" >> ${REC%.fsa}.cmt
-		echo "URL	https://github.com/mtisza1/Cenote-Taker3" >> ${REC%.fsa}.cmt	
-	done
+	python ${CENOTE_SCRIPTS}/python_modules/make_sequin_cmts.py\
+	  ${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv\
+	  ${C_OUTDIR}/sequin_and_genome_maps\
+	  $ASSEMBLER $SEQTECH
+#	for REC in $FSA_FILES ; do
+#		if [ -s ${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv ] ; then
+#			COVERAGE=$( awk -v SEQNAME="${REC%.fsa}" '{OFS=FS="\t"}{ if ($1 == SEQNAME) {print $7}}' \
+#				${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv | head -n1 )
+#
+#		else
+#			COVERAGE=1
+#		fi
+#
+#		echo "StructuredCommentPrefix	##Genome-Assembly-Data-START##" > ${REC%.fsa}.cmt
+#		echo "Assembly Method	${ASSEMBLER}" >> ${REC%.fsa}.cmt
+#		echo "Genome Coverage	"$COVERAGE"x" >> ${REC%.fsa}.cmt
+#		echo "Sequencing Technology	Illumina" >> ${REC%.fsa}.cmt
+#		echo "Annotation Pipeline	Cenote-Taker 3" >> ${REC%.fsa}.cmt
+#		echo "URL	https://github.com/mtisza1/Cenote-Taker3" >> ${REC%.fsa}.cmt	
+#	done
 fi
 
 ### Merge final virus seqs
@@ -1298,6 +1304,7 @@ fi
 #--  ${TEMP_DIR}/reORF/contig_gcodes1.txt
 #--  ${TEMP_DIR}/hallmark_tax/phanotate_seqs1.txt
 #--  ${TEMP_DIR}/contig_to_organism.tsv
+#--  ${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv
 #- output: -#
 #--  ${C_OUTDIR}/${run_title}_virus_summary.tsv
 #----	fields
@@ -1314,7 +1321,8 @@ if [ -s ${C_OUTDIR}/final_genes_to_contigs_annotation_summary.tsv ] ; then
 	python ${CENOTE_SCRIPTS}/python_modules/virus_summary.py ${TEMP_DIR}/contig_name_map.tsv \
 	  ${C_OUTDIR}/final_genes_to_contigs_annotation_summary.tsv ${TEMP_DIR}/final_taxonomy/virus_taxonomy_summary.tsv \
 	  ${C_OUTDIR} ${run_title} ${TEMP_DIR}/reORF/contig_gcodes1.txt\
-	  ${TEMP_DIR}/hallmark_tax/phanotate_seqs1.txt $CALLER ${TEMP_DIR}/contig_to_organism.tsv
+	  ${TEMP_DIR}/hallmark_tax/phanotate_seqs1.txt $CALLER ${TEMP_DIR}/contig_to_organism.tsv\
+	  ${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv
 
 	python ${CENOTE_SCRIPTS}/python_modules/summary_statement.py\
 	  ${C_OUTDIR}/${run_title}.contigs_over_${LENGTH_MINIMUM}nt.fasta $LENGTH_MINIMUM\

--- a/src/cenote/cenote_main.sh
+++ b/src/cenote/cenote_main.sh
@@ -33,6 +33,7 @@ ASSEMBLER=${28}
 MOL_TYPE=${29}
 DATA_SOURCE=${30}
 GENBANK=${31}
+TAXDBV=${32}
 
 ### check output directory (created in cenotetaker3.py)
 
@@ -472,11 +473,11 @@ else
 			mmseqs createdb ${TEMP_DIR}/hallmark_tax/orig_hallmark_genes.faa ${TEMP_DIR}/hallmark_tax/orig_hallmark_genesDB -v 1
 
 			mmseqs search ${TEMP_DIR}/hallmark_tax/orig_hallmark_genesDB\
-			  ${C_DBS}/mmseqs_DBs/refseq_virus_prot_taxDB\
+			  ${C_DBS}/mmseqs_DBs/${TAXDBV}\
 			  ${TEMP_DIR}/hallmark_tax/orig_hallmarks_resDB ${TEMP_DIR}/hallmark_tax/tmp -v 1 --start-sens 1 --sens-steps 3 -s 7
 
 			mmseqs convertalis ${TEMP_DIR}/hallmark_tax/orig_hallmark_genesDB\
-			  ${C_DBS}/mmseqs_DBs/refseq_virus_prot_taxDB\
+			  ${C_DBS}/mmseqs_DBs/${TAXDBV}\
 			  ${TEMP_DIR}/hallmark_tax/orig_hallmarks_resDB ${TEMP_DIR}/hallmark_tax/orig_hallmarks_align.tsv\
 			  --format-output query,target,pident,alnlen,evalue,theader,taxlineage -v 1
 
@@ -1133,11 +1134,11 @@ if [ -s ${TEMP_DIR}/virion_reORF_pyhmmer/hit_this_round1.txt ] ; then
 		mmseqs createdb ${TEMP_DIR}/final_taxonomy/hallmark_proteins.faa ${TEMP_DIR}/final_taxonomy/hallmark_proteinsDB -v 1
 
 		mmseqs search ${TEMP_DIR}/final_taxonomy/hallmark_proteinsDB\
-		  ${C_DBS}/mmseqs_DBs/refseq_virus_prot_taxDB\
+		  ${C_DBS}/mmseqs_DBs/${TAXDBV}\
 		  ${TEMP_DIR}/final_taxonomy/hallmark_proteins_resDB ${TEMP_DIR}/final_taxonomy/tmp -v 1 --start-sens 1 --sens-steps 3 -s 7
 
 		mmseqs convertalis ${TEMP_DIR}/final_taxonomy/hallmark_proteinsDB\
-		  ${C_DBS}/mmseqs_DBs/refseq_virus_prot_taxDB\
+		  ${C_DBS}/mmseqs_DBs/${TAXDBV}\
 		  ${TEMP_DIR}/final_taxonomy/hallmark_proteins_resDB ${TEMP_DIR}/final_taxonomy/hallmark_proteins_align.tsv\
 		  --format-output query,target,pident,alnlen,evalue,theader,taxlineage -v 1
 

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -227,9 +227,11 @@ def cenotetaker3():
                                 the first nucleotide in the contig/genome')
     optional_args.add_argument("--genbank", dest="GENBANK", type=str2bool, default="True", 
                             help='Default: True -- Make GenBank files (.gbf, .sqn, .fsa, .tbl, .cmt, etc)?')
-    optional_args.add_argument("--taxdb", dest="TAXDB", type=str, choices=['refseq', 'nr90'],
-                            default='nr90', 
-                            help='Default: nr90 -- Which taxonomy database to use, refseq virus OR nr clustered at 90 percent AAI and filtered down to virus hallmark genes')
+    optional_args.add_argument("--taxdb", dest="TAXDB", type=str, choices=['refseq', 'hallmark'],
+                            default='hallmark', 
+                            help='Default: hallmark -- Which taxonomy database to use, just refseq virus OR virus hallmark genes \
+                                from nr virus containing genus, family, and class taxonomy labels and clustered at 90 percent \
+                                AAI plus all hallmark genes from refseq virus')
     optional_args.add_argument("--seqtech", dest="SEQTECH", type=str,
                             default='Illumina', 
                             help='Default: Illumina -- Which sequencing technology produced the reads?')
@@ -292,7 +294,8 @@ def cenotetaker3():
         TAXDBV = 'refseq_virus_prot_taxDB'
     elif args.TAXDB == 'nr90':
         TAXDBV = 'ct3_hallmark_nr_virus.cd90.taxDB'
-    
+    elif args.TAXDB == 'hallmark':
+        TAXDBV = 'ct3_hallmark.taxDB'
 
     ## check that all DBs exist
     def check_ct3_dbs():

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -230,7 +230,9 @@ def cenotetaker3():
     optional_args.add_argument("--taxdb", dest="TAXDB", type=str, choices=['refseq', 'nr90'],
                             default='nr90', 
                             help='Default: nr90 -- Which taxonomy database to use, refseq virus OR nr clustered at 90 percent AAI and filtered down to virus hallmark genes')
-
+    optional_args.add_argument("--seqtech", dest="SEQTECH", type=str,
+                            default='Illumina', 
+                            help='Default: Illumina -- Which sequencing technology produced the reads?')
     args = parser.parse_args()
 
     ## annotation mode overrides other arguments
@@ -407,7 +409,7 @@ def cenotetaker3():
                     str(args.isolation_source), str(args.collection_date), str(args.metagenome_type), 
                     str(args.srr_number), str(args.srx_number), str(args.biosample), 
                     str(args.bioproject), str(args.ASSEMBLER), str(args.MOLECULE_TYPE), 
-                    str(args.DATA_SOURCE), str(args.GENBANK), str(TAXDBV)],
+                    str(args.DATA_SOURCE), str(args.GENBANK), str(TAXDBV), str(args.SEQTECH)],
                     stdout=PIPE, stderr=STDOUT)
 
     with process.stdout:

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -79,7 +79,7 @@ def cenotetaker3():
 
     parentpath = Path(pathname).parents[1]
 
-    __version__ = "3.2.1"
+    __version__ = "3.3.0"
 
     Def_CPUs = os.cpu_count()
 

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -227,6 +227,9 @@ def cenotetaker3():
                                 the first nucleotide in the contig/genome')
     optional_args.add_argument("--genbank", dest="GENBANK", type=str2bool, default="True", 
                             help='Default: True -- Make GenBank files (.gbf, .sqn, .fsa, .tbl, .cmt, etc)?')
+    optional_args.add_argument("--taxdb", dest="TAXDB", type=str, choices=['refseq', 'nr90'],
+                            default='nr90', 
+                            help='Default: nr90 -- Which taxonomy database to use, refseq virus OR nr clustered at 90 percent AAI and filtered down to virus hallmark genes')
 
     args = parser.parse_args()
 
@@ -282,6 +285,13 @@ def cenotetaker3():
     elif args.C_DBS == "default":
         args.C_DBS = parentpath
 
+    ## format TAXDB call
+    if args.TAXDB == 'refseq':
+        TAXDBV = 'refseq_virus_prot_taxDB'
+    elif args.TAXDB == 'nr90':
+        TAXDBV = 'ct3_hallmark_nr_virus.cd90.1.taxDB'
+    
+
     ## check that all DBs exist
     def check_ct3_dbs():
         ## checking db path
@@ -320,9 +330,9 @@ def cenotetaker3():
                 logger.warning("Exiting.")
                 sys.exit()
         ## checking mmseqs tax db
-        if not os.path.isfile(os.path.join(str(args.C_DBS), 'mmseqs_DBs', 'refseq_virus_prot_taxDB')):
+        if not os.path.isfile(os.path.join(str(args.C_DBS), 'mmseqs_DBs', str(TAXDBV))):
             logger.warning(f"mmseqs tax db file is not found at")
-            logger.warning(f"{os.path.join(str(args.C_DBS), 'mmseqs_DBs', 'refseq_virus_prot_taxDB')}")
+            logger.warning(f"{os.path.join(str(args.C_DBS), 'mmseqs_DBs', str(TAXDBV))}")
             logger.warning("Check instructions at https://github.com/mtisza1/Cenote-Taker3 for installing databases\
                            and setting CENOTE_DBS environmental variable")
             logger.warning("Exiting.")
@@ -397,7 +407,7 @@ def cenotetaker3():
                     str(args.isolation_source), str(args.collection_date), str(args.metagenome_type), 
                     str(args.srr_number), str(args.srx_number), str(args.biosample), 
                     str(args.bioproject), str(args.ASSEMBLER), str(args.MOLECULE_TYPE), 
-                    str(args.DATA_SOURCE), str(args.GENBANK)],
+                    str(args.DATA_SOURCE), str(args.GENBANK), str(TAXDBV)],
                     stdout=PIPE, stderr=STDOUT)
 
     with process.stdout:

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -289,7 +289,7 @@ def cenotetaker3():
     if args.TAXDB == 'refseq':
         TAXDBV = 'refseq_virus_prot_taxDB'
     elif args.TAXDB == 'nr90':
-        TAXDBV = 'ct3_hallmark_nr_virus.cd90.1.taxDB'
+        TAXDBV = 'ct3_hallmark_nr_virus.cd90.taxDB'
     
 
     ## check that all DBs exist

--- a/src/cenote/get_ct3_databases.py
+++ b/src/cenote/get_ct3_databases.py
@@ -20,8 +20,9 @@ def get_ct3_dbs():
     #print(cenote_script_path) 
 
     parser = argparse.ArgumentParser(description='Update and/or download databases associated with \
-                                    Cenote-Taker 3. HMM (hmmer) databases: updated October 8th 2023.\
-                                    RefSeq Virus taxonomy DB compiled July 31, 2023.')
+                                    Cenote-Taker 3. HMM (hmmer) databases: updated January 10th, 2024.\
+                                    RefSeq Virus taxonomy DB compiled July 31, 2023.\
+                                    hallmark taxonomy database added March 19th, 2024')
 
     required_args = parser.add_argument_group(' REQUIRED ARGUMENTS')
 
@@ -32,7 +33,9 @@ def get_ct3_dbs():
 
     optional_args.add_argument("--hmm", dest="HMM_DB", type=str2bool, default=False, 
                             help=' Default: False -- choose: True -or- False')
-    optional_args.add_argument("--mmseqs_tax", dest="MMSEQS_TAX", type=str2bool, default=False, 
+    optional_args.add_argument("--refseq_tax", dest="REFSEQ_TAX", type=str2bool, default=False, 
+                            help=' Default: False -- choose: True -or- False')
+    optional_args.add_argument("--hallmark_tax", dest="HALLMARK_TAX", type=str2bool, default=False, 
                             help=' Default: False -- choose: True -or- False')
     optional_args.add_argument("--mmseqs_cdd", dest="MMSEQS_CDD", type=str2bool, default=False, 
                             help=' Default: False -- choose: True -or- False')
@@ -61,21 +64,21 @@ def get_ct3_dbs():
         sys.exit()
 
     if str(args.HMM_DB) == "True":
-        # https://zenodo.org/records/10480890/files/hmmscan_DBs.tgz
+        # https://zenodo.org/records/10840546/files/hmmscan_DBs.tgz
         print ("running HMM database update/install")
         HMM_outdir = os.path.join(str(args.C_DBS), "hmmscan_DBs")
         if not os.path.isdir(HMM_outdir):
             os.makedirs(HMM_outdir, exist_ok=True)
         subprocess.call(['wget', '--directory-prefix=' + str(HMM_outdir), 
-                        'https://zenodo.org/records/10480890/files/hmmscan_DBs.tgz'])
+                        'https://zenodo.org/records/10840546/files/hmmscan_DBs.tgz'])
         subprocess.call(['tar', '-xvf', os.path.join(HMM_outdir, 'hmmscan_DBs.tgz'),
                         '-C',  str(HMM_outdir)])
         subprocess.call(['rm', '-f', os.path.join(HMM_outdir, 'hmmscan_DBs.tgz')])
 
-    if str(args.MMSEQS_TAX) == "True":
-        # https://zenodo.org/records/10480890/files/refseq_virus_prot.fasta.gz
-        # https://zenodo.org/records/10480890/files/refseq_virus_prot_taxids.mmseqs_fmt.tsv
-        print ("running mmseqs taxdb database update/install")
+    if str(args.REFSEQ_TAX) == "True":
+        # https://zenodo.org/records/10840546/files/refseq_virus_prot.fasta.gz
+        # https://zenodo.org/records/10840546/files/ct3_hallmark_nr_cd90_refseq.prot_taxids.mmseqs_fmt.tsv
+        print ("running mmseqs refseq taxdb database update/install")
         if not is_tool("mmseqs") :
             print("mmseqs is not found. Exiting. Is conda environment activated?")
             sys.exit()
@@ -83,22 +86,44 @@ def get_ct3_dbs():
         if not os.path.isdir(MMSEQS_outdir):
             os.makedirs(MMSEQS_outdir, exist_ok=True)
         subprocess.call(['wget', '--directory-prefix=' + str(MMSEQS_outdir), 
-                        'https://zenodo.org/records/10480890/files/refseq_virus_prot.fasta.gz'])
+                        'https://zenodo.org/records/10840546/files/refseq_virus_prot.fasta.gz'])
         subprocess.call(['gunzip', '-d', os.path.join(MMSEQS_outdir, 'refseq_virus_prot.fasta.gz')])
         #subprocess.call(['rm', '-f', os.path.join(MMSEQS_outdir, 'refseq_virus_prot.fasta.gz')])
         subprocess.call(['wget', '--directory-prefix=' + str(MMSEQS_outdir), 
-                        'https://zenodo.org/records/10480890/files/refseq_virus_prot_taxids.mmseqs_fmt.tsv'])
+                        'https://zenodo.org/records/10840546/files/ct3_hallmark_nr_cd90_refseq.prot_taxids.mmseqs_fmt.tsv'])
         subprocess.call(['mmseqs', 'createdb', os.path.join(MMSEQS_outdir, 'refseq_virus_prot.fasta'), 
                         os.path.join(MMSEQS_outdir, 'refseq_virus_prot_taxDB')])
         subprocess.call(['mmseqs', 'createtaxdb', os.path.join(MMSEQS_outdir, 'refseq_virus_prot_taxDB'), 
                         os.path.join(MMSEQS_outdir, 'tmp'), '--tax-mapping-file', 
                         os.path.join(MMSEQS_outdir, 'refseq_virus_prot_taxids.mmseqs_fmt.tsv')])
 
+    if str(args.HALLMARK_TAX) == "True":
+        # https://zenodo.org/records/10840546/files/ct3_hallmark_nr_cd90_refseq.faa.gz
+        # https://zenodo.org/records/10840546/files/ct3_hallmark_nr_cd90_refseq.prot_taxids.mmseqs_fmt.tsv
+        print ("running mmseqs hallmark taxdb database update/install")
+        if not is_tool("mmseqs") :
+            print("mmseqs is not found. Exiting. Is conda environment activated?")
+            sys.exit()
+        MMSEQS_outdir = os.path.join(str(args.C_DBS), "mmseqs_DBs")
+        if not os.path.isdir(MMSEQS_outdir):
+            os.makedirs(MMSEQS_outdir, exist_ok=True)
+        subprocess.call(['wget', '--directory-prefix=' + str(MMSEQS_outdir), 
+                        'https://zenodo.org/records/10840546/files/ct3_hallmark_nr_cd90_refseq.faa.gz'])
+        subprocess.call(['gunzip', '-d', os.path.join(MMSEQS_outdir, 'ct3_hallmark_nr_cd90_refseq.faa.gz')])
+        #subprocess.call(['rm', '-f', os.path.join(MMSEQS_outdir, 'ct3_hallmark_nr_cd90_refseq.faa.gz')])
+        subprocess.call(['wget', '--directory-prefix=' + str(MMSEQS_outdir), 
+                        'https://zenodo.org/records/10840546/files/ct3_hallmark_nr_cd90_refseq.prot_taxids.mmseqs_fmt.tsv'])
+        subprocess.call(['mmseqs', 'createdb', os.path.join(MMSEQS_outdir, 'ct3_hallmark_nr_cd90_refseq.faa'), 
+                        os.path.join(MMSEQS_outdir, 'ct3_hallmark.taxDB')])
+        subprocess.call(['mmseqs', 'createtaxdb', os.path.join(MMSEQS_outdir, 'ct3_hallmark.taxDB'), 
+                        os.path.join(MMSEQS_outdir, 'tmp'), '--tax-mapping-file', 
+                        os.path.join(MMSEQS_outdir, 'ct3_hallmark_nr_cd90_refseq.prot_taxids.mmseqs_fmt.tsv')])
+        
     if str(args.MMSEQS_CDD) == "True":
-        # https://zenodo.org/records/10480890/files/cddid_all.tbl
+        # https://zenodo.org/records/10840546/files/cddid_all.tbl
         print ("running mmseqs CDD database update/install")
         subprocess.call(['wget', '--directory-prefix=' + str(MMSEQS_outdir), 
-                        'https://zenodo.org/records/10480890/files/cddid_all.tbl'])
+                        'https://zenodo.org/records/10840546/files/cddid_all.tbl'])
         if not is_tool("mmseqs") :
             print("mmseqs is not found. Exiting. Is conda environment activated?")
             sys.exit()
@@ -110,10 +135,10 @@ def get_ct3_dbs():
                         os.path.join(MMSEQS_outdir, 'tmp')])
 
 
-    # https://zenodo.org/records/10480890/files/viral_cdds_and_pfams_191028.txt
+    # https://zenodo.org/records/10840546/files/viral_cdds_and_pfams_191028.txt
     if str(args.DOM_LIST) == "True":
         subprocess.call(['wget', '--directory-prefix=' + str(args.C_DBS), 
-                        'https://zenodo.org/records/10480890/files/viral_cdds_and_pfams_191028.txt'])
+                        'https://zenodo.org/records/10840546/files/viral_cdds_and_pfams_191028.txt'])
 
     if str(args.HHCDD) == "True":
         print ("running hhsuite CDD database update/install")

--- a/src/cenote/python_modules/assess_virus_genes1.py
+++ b/src/cenote/python_modules/assess_virus_genes1.py
@@ -269,12 +269,14 @@ if not long_df.empty:
         
     except:
         
-
-        os.mkdir(os.path.join(out_dir, "prune_figures"))
+        if not os.path.isdir(os.path.join(out_dir, "prune_figures")):
+            os.mkdir(os.path.join(out_dir, "prune_figures"))
 
 else:
     print(f"{os.path.basename(__file__)}: No non-DTR virus contigs >= 10,000 nt. So pruning will not happen")
-    os.mkdir(os.path.join(out_dir, "prune_figures"))
+
+    if not os.path.isdir(os.path.join(out_dir, "prune_figures")):
+        os.mkdir(os.path.join(out_dir, "prune_figures"))
 
 
 

--- a/src/cenote/python_modules/hhpred_to_table.py
+++ b/src/cenote/python_modules/hhpred_to_table.py
@@ -24,55 +24,58 @@ if not hhrout_list:
 rows = []
 
 for hhresult_file in hhrout_list:
-    with open(hhresult_file, 'r') as hrh:
-        for line in hrh:
-            if line.startswith('Query         '):
-                gene_name = line.strip('Query         ').split(' ')[0]
-            
-            #with this logic, only files with results (lines starting with >) append the df
-            if line.startswith('>'):
-                full_desc = line.rstrip('\n').strip('>')
+    try:
+        with open(hhresult_file, 'r') as hrh:
+            for line in hrh:
+                if line.startswith('Query         '):
+                    gene_name = line.strip('Query         ').split(' ')[0]
+                
+                #with this logic, only files with results (lines starting with >) append the df
+                if line.startswith('>'):
+                    full_desc = line.rstrip('\n').strip('>')
 
-                ## CDD models
-                if line.startswith('>cd') or line.startswith('>sd'):
-                    accession = full_desc.split(' ')[0]
+                    ## CDD models
+                    if line.startswith('>cd') or line.startswith('>sd'):
+                        accession = full_desc.split(' ')[0]
 
-                    try:
-                        #annotation = full_desc.split('; ')[1].split('. ')[0]
-                        annotation = full_desc.split(' ')[1].split(';')[0]
-                    except:
-                        annotation = 'hypothetical protein'
+                        try:
+                            #annotation = full_desc.split('; ')[1].split('. ')[0]
+                            annotation = full_desc.split(' ')[1].split(';')[0]
+                        except:
+                            annotation = 'hypothetical protein'
 
-                ## PFAM models
-                elif line.startswith('>PF'):
-                    accession = full_desc.split(' ; ')[0]
+                    ## PFAM models
+                    elif line.startswith('>PF'):
+                        accession = full_desc.split(' ; ')[0]
 
-                    try:
-                        annotation = full_desc.split('; ')[2]
-                    except:
-                        annotation = 'hypothetical protein'
+                        try:
+                            annotation = full_desc.split('; ')[2]
+                        except:
+                            annotation = 'hypothetical protein'
 
-                ## PDB models
-                else:
-                    accession = full_desc.split(' ')[0]
+                    ## PDB models
+                    else:
+                        accession = full_desc.split(' ')[0]
 
-                    try:
-                        annotationpd = full_desc.split(' ')[1:]
-                        annotationpd = ' '.join(annotationpd)
-                        if ']' in annotationpd:
-                            annotation = annotationpd.split(']')[1].split(';')[0]
-                        else:
-                            annotation = annotationpd.split(';')[0]
-                    except:
-                        annotation = 'hypothetical protein'
+                        try:
+                            annotationpd = full_desc.split(' ')[1:]
+                            annotationpd = ' '.join(annotationpd)
+                            if ']' in annotationpd:
+                                annotation = annotationpd.split(']')[1].split(';')[0]
+                            else:
+                                annotation = annotationpd.split(';')[0]
+                        except:
+                            annotation = 'hypothetical protein'
 
-                full_stats = next(hrh, '').strip()
-                probability = full_stats.split('  ')[0].split('=')[1]
-                evalue = full_stats.split('  ')[1].split('=')[1]
-                Aligned_cols = full_stats.split('  ')[3].split('=')[1]
-                row = [gene_name, accession, annotation, probability, evalue, Aligned_cols]
+                    full_stats = next(hrh, '').strip()
+                    probability = full_stats.split('  ')[0].split('=')[1]
+                    evalue = full_stats.split('  ')[1].split('=')[1]
+                    Aligned_cols = full_stats.split('  ')[3].split('=')[1]
+                    row = [gene_name, accession, annotation, probability, evalue, Aligned_cols]
 
-                rows.append(row)
+                    rows.append(row)
+    except Exception as e:
+        print(hhresult_file, e)
 
 hhpred_df = pd.DataFrame(rows, columns=['gene_name', 'evidence_acession', 'evidence_description', 
                                         'evidence_prob', 'evalue', 'Aligned_cols'])

--- a/src/cenote/python_modules/make_sequin_cmts.py
+++ b/src/cenote/python_modules/make_sequin_cmts.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+import subprocess
+import os
+import sys
+import pandas as pd
+
+
+samtools_cov = sys.argv[1]
+
+sequin_dir = sys.argv[2]
+
+assembler = sys.argv[3]
+
+seqtech = sys.argv[4]
+
+# make list of fsa files
+fsa_list = []
+for fsa in os.listdir(sequin_dir):
+    if fsa.endswith('.fsa'):
+        f = os.path.join(sequin_dir, fsa)
+
+        if os.path.isfile(f) and os.path.getsize(f) > 0:
+            fsa_list.append(f)
+
+if not fsa_list:
+    print(f"{os.path.basename(__file__)}: no .fsa files found in " + str(sequin_dir))
+    sys.exit()
+
+# makes empty dataframe if samtools coverage table wasn't created
+try:
+    sam_df = pd.read_csv(samtools_cov, sep = "\t", header = 0)
+except:
+    sam_df = pd.DataFrame()
+
+
+# matches coverage to contig by name
+for fsa_file in fsa_list:
+    with open(fsa_file) as fsaf:
+        contig = fsaf.readline().strip('\n').strip('>').split(' ')[0]
+
+        try:
+            coverage: float = float(sam_df['coverage'][sam_df['#rname'] == contig].iloc[0,])
+
+        except:
+            coverage = 0
+        
+        out_cmt = os.path.splitext(fsa_file)[0]+'.cmt'
+        
+        try:
+            # cmt file 
+            print(f'StructuredCommentPrefix\t##Genome-Assembly-Data-START##\n'
+                f'Assembly Method\t{assembler}\n'
+                f'Genome Coverage\t{coverage:.2f}x\n'
+                f'Sequencing Technology\t{seqtech}\n'
+                f'Annotation Pipeline\tCenote-Taker 3\n'
+                f'URL\thttps://github.com/mtisza1/Cenote-Taker3',
+                file = open(out_cmt, "a"))
+        except Exception as e:
+            print(e)

--- a/src/cenote/python_modules/summary_statement.py
+++ b/src/cenote/python_modules/summary_statement.py
@@ -22,7 +22,11 @@ num_seqs = sum( 1 for _ in enumerate(SeqIO.parse(in_fna, "fasta")))
 
 gene_df = pd.read_csv(genes_sum, sep = '\t', header = 0)
 
-num_virus_contigs = len(gene_df['contig'].drop_duplicates())
+gene_df['chunk_name'] = gene_df['chunk_name'].infer_objects(copy=False).fillna("NaN")
+
+gene_df['contig_chunk'] = gene_df['contig'] + "@" + gene_df['chunk_name']
+
+num_virus_contigs = len(gene_df['contig_chunk'].drop_duplicates())
 
 all_genes = len(gene_df['gene_name'].drop_duplicates())
 nonhypo_genes = len(gene_df.query('evidence_description != "hypothetical protein"')['gene_name'].drop_duplicates())

--- a/src/cenote/python_modules/virus_summary.py
+++ b/src/cenote/python_modules/virus_summary.py
@@ -104,7 +104,7 @@ merge_df = pd.merge(merge_df, gcode_df, on = "contig", how = "left")
 if not sam_df.empty:
     merge_df = pd.merge(merge_df, sam_df, on = ["contig", "chunk_name"], how = "left")
 else:
-    merge_df['coverage'] = 0
+    merge_df['coverage'] = "NaN"
 
 merge_df['taxon'] = merge_df['taxon'].infer_objects(copy=False).fillna("unclassified virus")
 


### PR DESCRIPTION
redoing read coverage parsing from samtools coverage: `make_sequin_cmts.py`

Adding read coverage to summary table. Adding virus gcode to virus summary table: `virus_summary.py`

Fixing minor error/warning when trying to create a directory that exists: `assess_virus_genes1.py`

adding sequencing tech argument `--seqtech`

Added/integrated a new taxonomy database "hallmark". This database is compiled from: 1) genbank nr clustered -> extracting virus proteins with taxonomical labels for genus, family, and class -> filtering to seqs with CT3 hallmark gene hits -> reclustering at 90% AAI with `cd-hit` and 2) refseq virus -> filtering to seqs with CT3 hallmark gene hits
