### PR TITLE
Update4, to v3.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Image of example genome map:
 
 1) Not for read-level classification of known viruses (see [Marker-MAGu](https://github.com/cmmr/Marker-MAGu) or [EsViritu](https://github.com/cmmr/EsViritu) for this task)
 
-2) Not ideal for annotating virus genomes that are highly similar to known references (e.g. phage lambda with a few mutations)
+2) Not ideal for annotating virus genomes that are highly similar to known references (e.g. phage lambda with a few mutations).
 
 ## Schematic
 
@@ -53,7 +53,7 @@ Image of example genome map:
 
 **Most recent versions**
 
-Cenote-Taker 3 scripts:   `v3.3.0`
+Cenote-Taker 3 scripts:   `v3.3.1`
 Cenote-Taker 3 Databases: `v3.1.1`
 
 **This should work on MacOS and Linux**
@@ -80,15 +80,20 @@ conda 23.7.4
 
 </details>
 
+2)  Activate the conda environment.
+
+`conda activate ct3_env`
+
+
 *You should be able to type `cenotetaker3` and `get_ct3_dbs` in terminal to bring up help menu now*
 
-2)  Change to a directory where you'd like to install databases and run database script, specify DB directory with `-o`.
+3)  Change to a directory where you'd like to install databases and run database script, specify DB directory with `-o`.
 
 *Total DB file size of 3.0 GB after file decompression*
 
 `cd ..`
 
-`get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --mmseqs_cdd T --domain_list T`
+`get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --refseq_tax  T --mmseqs_cdd T --domain_list T`
 
 <details>
 
@@ -107,12 +112,12 @@ conda 23.7.4
   | pdb70    | 56 GB  |
   
   ```         
-  get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --mmseqs_cdd T --domain_list T --hhCDD T --hhPFAM T --hhPDB T
+  get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --refseq_tax T --mmseqs_cdd T --domain_list T --hhCDD T --hhPFAM T --hhPDB T
   ```
 
 </details>
 
-3)  Set the database directory as a conda environmental variable.
+4)  Set the database directory as a conda environmental variable.
 
 `conda env config vars set CENOTE_DBS=/path/to/ct3_DBs`
 
@@ -142,7 +147,7 @@ conda 23.7.4
 
 `cd ..`
 
-`get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --mmseqs_cdd T --domain_list T`
+`get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --refseq_tax T --mmseqs_cdd T --domain_list T`
 
 <details>
 
@@ -161,7 +166,7 @@ conda 23.7.4
   | pdb70    | 56 GB  |
   
   ```         
-  get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --mmseqs_cdd T --domain_list T --hhCDD T --hhPFAM T --hhPDB T
+  get_ct3_dbs -o ct3_DBs --hmm T --hallmark_tax T --refseq_tax T --mmseqs_cdd T --domain_list T --hhCDD T --hhPFAM T --hhPDB T
   ```
 
 </details>
@@ -198,7 +203,7 @@ cenotetaker3 -c my_metagenome_contigs.fna -r my_meta_ct3 -p T
 cenotetaker3 -c my_metagenome_contigs.fna -r my_meta_ct3 -p T --lin_minimum_hallmark_genes 2
 ```
 
-### Discover and Annotate, Force `prodigal` (prodigal-gv is default)
+### Discover and Annotate, Force `prodigal` (`prodigal-gv` is default)
 
 ```         
 cenotetaker3 -c my_metagenome_contigs.fna -r my_meta_ct3pr -p T --caller prodigal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cenotetaker3"
-version = "3.3.0"
+version = "3.3.1"
 authors = [
   { name="Mike Tisza", email="michael.tisza@gmail.com" },
 ]

--- a/src/cenote/cenote_main.sh
+++ b/src/cenote/cenote_main.sh
@@ -151,6 +151,9 @@ echo "Template file:                     $TEMPLATE_FILE" >> ${C_OUTDIR}/run_argu
 echo "read file(s):                      $READS" >> ${C_OUTDIR}/run_arguments.txt
 echo "HHsuite tool:                      $HHSUITE_TOOL" >> ${C_OUTDIR}/run_arguments.txt
 echo "Taxonomy DB:                       $TAXDBV" >> ${C_OUTDIR}/run_arguments.txt
+echo "Sequencing Technology:             $SEQTECH" >> ${C_OUTDIR}/run_arguments.txt
+echo "Max seq length to assess DTRs:     $MAX_LENGTH_DTR" >> ${C_OUTDIR}/run_arguments.txt
+
 
 
 cat ${C_OUTDIR}/run_arguments.txt

--- a/src/cenote/cenote_main.sh
+++ b/src/cenote/cenote_main.sh
@@ -1100,7 +1100,15 @@ if [ -s ${TEMP_DIR}/oriented_hallmark_contigs.pruned.fasta ] && [ "${READS}" != 
 		mkdir ${TEMP_DIR}/mapping_reads
 	fi
 
-	minimap2 -t $CPU -ax sr ${TEMP_DIR}/oriented_hallmark_contigs.pruned.fasta ${READS} |\
+	if [ "$SEQTECH" == "Oxford Nanopore" ] || [ "$SEQTECH" == "Nanopore" ] ; then
+		MM_OPTIONS="map-ont"
+	elif [ "$SEQTECH" == "PacBio" ] ; then
+		MM_OPTIONS="map-hifi"
+	else
+		MM_OPTIONS="sr"
+	fi
+
+	minimap2 -t $CPU -ax "${MM_OPTIONS}" ${TEMP_DIR}/oriented_hallmark_contigs.pruned.fasta ${READS} |\
 	  samtools sort - | samtools coverage -o ${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv -
 
 else
@@ -1233,7 +1241,7 @@ if [ -n "$FSA_FILES" ] && [ "$GENBANK" == "True" ] ; then
 	python ${CENOTE_SCRIPTS}/python_modules/make_sequin_cmts.py\
 	  ${TEMP_DIR}/mapping_reads/oriented_hallmark_contigs.pruned.coverage.tsv\
 	  ${C_OUTDIR}/sequin_and_genome_maps\
-	  $ASSEMBLER $SEQTECH
+	  $ASSEMBLER "$SEQTECH"
 
 fi
 

--- a/src/cenote/cenote_main.sh
+++ b/src/cenote/cenote_main.sh
@@ -35,6 +35,7 @@ DATA_SOURCE=${30}
 GENBANK=${31}
 TAXDBV=${32}
 SEQTECH=${33}
+MAX_LENGTH_DTR=${34}
 
 ### check output directory (created in cenotetaker3.py)
 
@@ -72,9 +73,11 @@ if [ -n "$PDB_HHSUITE" ] ; then
 	HHSUITE_DB_STR="${HHSUITE_DB_STR}-d ${PDB_HHSUITE}"
 fi
 if [ ! -n "$HHSUITE_DB_STR" ] ; then
-	echo "HHsuite databases not found at ${C_DBS}/hhsearch_DBs"
-	echo "$HHSUITE_TOOL will not be run"
-	HHSUITE_TOOL="none"
+	if [ "$HHSUITE_TOOL" != "none" ] ; then
+		echo "HHsuite databases not found at ${C_DBS}/hhsearch_DBs"
+		echo "$HHSUITE_TOOL will not be run"
+		HHSUITE_TOOL="none"
+	fi
 fi
 
 
@@ -323,7 +326,7 @@ if [ -s ${TEMP_DIR}/unprocessed_hallmark_contigs.fasta ] ; then
 
 	python ${CENOTE_SCRIPTS}/python_modules/terminal_repeats.py ${TEMP_DIR}/unprocessed_hallmark_contigs.fasta\
 	${TEMP_DIR}/hallmarks_per_orig_contigs.tsv $circ_length_cutoff $linear_length_cutoff $CIRC_MINIMUM_DOMAINS\
-	$LIN_MINIMUM_DOMAINS ${TEMP_DIR} $WRAP
+	$LIN_MINIMUM_DOMAINS ${TEMP_DIR} $WRAP $MAX_LENGTH_DTR
 
 	if [ -s ${TEMP_DIR}/trimmed_TRs_hallmark_contigs.fasta ] && [ -s ${TEMP_DIR}/contigs_over_threshold.txt ] ; then
 		

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -234,7 +234,8 @@ def cenotetaker3():
                                 AAI plus all hallmark genes from refseq virus')
     optional_args.add_argument("--seqtech", dest="SEQTECH", type=str,
                             default='Illumina', 
-                            help='Default: Illumina -- Which sequencing technology produced the reads?')
+                            help='Default: Illumina -- Which sequencing technology produced the reads? \
+                                Common options: Illumina, Oxford Nanopore, PacBio, Onso, Aviti')
     args = parser.parse_args()
 
     ## annotation mode overrides other arguments

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -235,7 +235,7 @@ def cenotetaker3():
     optional_args.add_argument("--seqtech", dest="SEQTECH", type=str,
                             default='Illumina', 
                             help='Default: Illumina -- Which sequencing technology produced the reads? \
-                                Common options: Illumina, Oxford Nanopore, PacBio, Onso, Aviti')
+                                Common options: Illumina, Nanopore, PacBio, Onso, Aviti')
     optional_args.add_argument("--max_dtr_assess", dest="MAXDTR", type=float,
                             default=1_000_000, 
                             help='Default: 1000000 -- maximum sequence length to assess DTRs. Extra long \

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -127,10 +127,10 @@ def cenotetaker3():
     optional_args.add_argument("--reads", nargs="+",
                                 dest="READS", default="none", 
                                 help='read file(s) in .fastq format. You can specify more than one separated by a space')
-    optional_args.add_argument("--minimum_length_circular", dest="circ_length_cutoff", type=int, default='1000', 
+    optional_args.add_argument("--minimum_length_circular", dest="circ_length_cutoff", type=int, default=1000, 
                             help='Default: 1000 -- Minimum length of contigs to be checked for circularity. Bare minimun is \
                                 1000 nts')
-    optional_args.add_argument("--minimum_length_linear", dest="linear_length_cutoff", type=int, default='1000', 
+    optional_args.add_argument("--minimum_length_linear", dest="linear_length_cutoff", type=int, default=1000, 
                             help='Default: 1000 -- Minimum length of non-circualr contigs to be checked for viral \
                                 hallmark genes.')
     optional_args.add_argument("-db", "--virus_domain_db", dest="HALL_LIST", type=str, choices=['virion', 'rdrp', 'dnarep'],
@@ -141,11 +141,11 @@ def cenotetaker3():
                                 rate. \'rdrp\' database: For RNA virus-derived RNA-dependent RNA polymerase. \
                                 \'dnarep\' database: replication genes of DNA viruses. mostly useful for small \
                                 DNA viruses, e.g. CRESS viruses')
-    optional_args.add_argument("--lin_minimum_hallmark_genes", dest="LIN_MINIMUM_DOMAINS", type=int, default='1', 
+    optional_args.add_argument("--lin_minimum_hallmark_genes", dest="LIN_MINIMUM_DOMAINS", type=int, default=1, 
                             help='Default: 1 -- Number of detected viral hallmark genes on a non-circular contig to be \
                                 considered viral and recieve full annotation. \
                                 \'2\' might be more suitable, yielding a false positive rate near 0. ')
-    optional_args.add_argument("--circ_minimum_hallmark_genes", dest="CIRC_MINIMUM_DOMAINS", type=int, default='1', 
+    optional_args.add_argument("--circ_minimum_hallmark_genes", dest="CIRC_MINIMUM_DOMAINS", type=int, default=1, 
                             help='Default:1 -- Number of detected viral hallmark genes on a circular contig to be \
                                 considered viral and recieve full annotation. For samples physically enriched for virus \
                                 particles, \'0\' can be used, but please treat circular contigs without known viral \
@@ -236,6 +236,12 @@ def cenotetaker3():
                             default='Illumina', 
                             help='Default: Illumina -- Which sequencing technology produced the reads? \
                                 Common options: Illumina, Oxford Nanopore, PacBio, Onso, Aviti')
+    optional_args.add_argument("--max_dtr_assess", dest="MAXDTR", type=float,
+                            default=1_000_000, 
+                            help='Default: 1000000 -- maximum sequence length to assess DTRs. Extra long \
+                                contigs with DTRs are likely to be bacterial chromosomes, not virus genomes.')
+
+    
     args = parser.parse_args()
 
     ## annotation mode overrides other arguments
@@ -303,8 +309,9 @@ def cenotetaker3():
         ## checking db path
         if not os.path.isdir(str(args.C_DBS)):
             logger.warning(f"database directory is not found at {str(args.C_DBS)}. Exiting.")
-            logger.warning("Check instructions at https://github.com/mtisza1/Cenote-Taker3 for installing databases\
-                           and setting CENOTE_DBS environmental variable")
+            logger.warning(f"Check instructions at https://github.com/mtisza1/Cenote-Taker3 "
+                           f"for installing databases "
+                           f"and setting CENOTE_DBS environmental variable")
             sys.exit()
         ## checking hmm dir
         if not os.path.isdir(os.path.join(str(args.C_DBS), 'hmmscan_DBs', str(args.HMM_DBS))):
@@ -319,9 +326,9 @@ def cenotetaker3():
                         if sec_dir == os.path.join(str(args.C_DBS), 'hmmscan_DBs'):
                             args.HMM_DBS = bottom_dir
                         else:
-                            logger.warning("Check instructions at https://github.com/mtisza1/Cenote-Taker3\
-                                           for installing databases\
-                                           and setting CENOTE_DBS environmental variable")
+                            logger.warning(f"Check instructions at https://github.com/mtisza1/Cenote-Taker3"
+                                           f"for installing databases"
+                                           f"and setting CENOTE_DBS environmental variable")
                             logger.warning("Exiting.")
                             sys.exit()
         ## checking hmm files
@@ -331,32 +338,36 @@ def cenotetaker3():
             if not os.path.isfile(os.path.join(str(args.C_DBS), 'hmmscan_DBs', str(args.HMM_DBS), hf)):
                 logger.warning(f"hmm db file is not found at")
                 logger.warning(f"{os.path.join(str(args.C_DBS), 'hmmscan_DBs', str(args.HMM_DBS), hf)}")
-                logger.warning("Check instructions at https://github.com/mtisza1/Cenote-Taker3 for installing databases\
-                            and setting CENOTE_DBS environmental variable")
+                logger.warning(f"Check instructions at https://github.com/mtisza1/Cenote-Taker3 "
+                            f"for installing databases "
+                            f"and setting CENOTE_DBS environmental variable")
                 logger.warning("Exiting.")
                 sys.exit()
         ## checking mmseqs tax db
         if not os.path.isfile(os.path.join(str(args.C_DBS), 'mmseqs_DBs', str(TAXDBV))):
             logger.warning(f"mmseqs tax db file is not found at")
             logger.warning(f"{os.path.join(str(args.C_DBS), 'mmseqs_DBs', str(TAXDBV))}")
-            logger.warning("Check instructions at https://github.com/mtisza1/Cenote-Taker3 for installing databases\
-                           and setting CENOTE_DBS environmental variable")
+            logger.warning(f"Check instructions at https://github.com/mtisza1/Cenote-Taker3 "
+                           f"for installing databases "
+                           f"and setting CENOTE_DBS environmental variable")
             logger.warning("Exiting.")
             sys.exit()
         ## checking mmseqs cdd db
         if not os.path.isfile(os.path.join(str(args.C_DBS), 'mmseqs_DBs', 'CDD')):
             logger.warning(f"mmseqs CDD db file is not found at")
             logger.warning(f"{os.path.join(str(args.C_DBS), 'mmseqs_DBs', 'CDD')}")
-            logger.warning("Check instructions at https://github.com/mtisza1/Cenote-Taker3 for installing databases\
-                           and setting CENOTE_DBS environmental variable")
+            logger.warning(f"Check instructions at https://github.com/mtisza1/Cenote-Taker3 "
+                           f"for installing databases "
+                           f"and setting CENOTE_DBS environmental variable")
             logger.warning("Exiting.")
             sys.exit()
          ## checking virus domain list file
         if not os.path.isfile(os.path.join(str(args.C_DBS), 'viral_cdds_and_pfams_191028.txt')):
             logger.warning(f"virus domain list file is not found at")
             logger.warning(f"{os.path.join(str(args.C_DBS), 'viral_cdds_and_pfams_191028.txt')}")
-            logger.warning("Check instructions at https://github.com/mtisza1/Cenote-Taker3 for installing databases\
-                           and setting CENOTE_DBS environmental variable")
+            logger.warning(f"Check instructions at https://github.com/mtisza1/Cenote-Taker3 "
+                           f"for installing databases "
+                           f"and setting CENOTE_DBS environmental variable")
             logger.warning("Exiting.")
             sys.exit()
 
@@ -392,8 +403,8 @@ def cenotetaker3():
         logger.info(str(args.run_title))
     else:
         logger.warning(f"{str(args.run_title)} is not a valid name for the run title ( -r argument)")
-        logger.warning( "the run title needs to be only letters, numbers and underscores (_) and \
-              18 characters or less. Exiting.")
+        logger.warning(f"the run title needs to be only letters, numbers and underscores (_) and "
+                       f"18 characters or less. Exiting.")
         sys.exit()
 
 
@@ -413,7 +424,8 @@ def cenotetaker3():
                     str(args.isolation_source), str(args.collection_date), str(args.metagenome_type), 
                     str(args.srr_number), str(args.srx_number), str(args.biosample), 
                     str(args.bioproject), str(args.ASSEMBLER), str(args.MOLECULE_TYPE), 
-                    str(args.DATA_SOURCE), str(args.GENBANK), str(TAXDBV), str(args.SEQTECH)],
+                    str(args.DATA_SOURCE), str(args.GENBANK), str(TAXDBV), str(args.SEQTECH),
+                    str(args.MAXDTR)],
                     stdout=PIPE, stderr=STDOUT)
 
     with process.stdout:

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -325,8 +325,13 @@ def cenotetaker3():
                         sec_dir = '/'.join(path.split('/')[0:-1])
                         if sec_dir == os.path.join(str(args.C_DBS), 'hmmscan_DBs'):
                             args.HMM_DBS = bottom_dir
+                            logger.warning(f"Found HMM DB v{args.HMM_DBS} in "
+                                           f"{os.path.join(str(args.C_DBS), 'hmmscan_DBs')} "
+                                           f"and it will be used in this run")
+                            logger.warning(f"Check instructions at https://github.com/mtisza1/Cenote-Taker3 "
+                                           f"for updating databases")
                         else:
-                            logger.warning(f"Check instructions at https://github.com/mtisza1/Cenote-Taker3"
+                            logger.warning(f"Check instructions at https://github.com/mtisza1/Cenote-Taker3 "
                                            f"for installing databases"
                                            f"and setting CENOTE_DBS environmental variable")
                             logger.warning("Exiting.")
@@ -339,8 +344,8 @@ def cenotetaker3():
                 logger.warning(f"hmm db file is not found at")
                 logger.warning(f"{os.path.join(str(args.C_DBS), 'hmmscan_DBs', str(args.HMM_DBS), hf)}")
                 logger.warning(f"Check instructions at https://github.com/mtisza1/Cenote-Taker3 "
-                            f"for installing databases "
-                            f"and setting CENOTE_DBS environmental variable")
+                                f"for installing databases "
+                                f"and setting CENOTE_DBS environmental variable")
                 logger.warning("Exiting.")
                 sys.exit()
         ## checking mmseqs tax db

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -79,7 +79,7 @@ def cenotetaker3():
 
     parentpath = Path(pathname).parents[1]
 
-    __version__ = "3.3.0"
+    __version__ = "3.3.1"
 
     Def_CPUs = os.cpu_count()
 

--- a/src/cenote/get_ct3_databases.py
+++ b/src/cenote/get_ct3_databases.py
@@ -54,6 +54,8 @@ def get_ct3_dbs():
     if not os.path.isdir(str(args.C_DBS)):
         os.makedirs(str(args.C_DBS))
 
+    MMSEQS_outdir = os.path.join(str(args.C_DBS), "mmseqs_DBs")
+
     def is_tool(name):
         """Check whether `name` is on PATH."""
         from distutils.spawn import find_executable
@@ -82,7 +84,7 @@ def get_ct3_dbs():
         if not is_tool("mmseqs") :
             print("mmseqs is not found. Exiting. Is conda environment activated?")
             sys.exit()
-        MMSEQS_outdir = os.path.join(str(args.C_DBS), "mmseqs_DBs")
+
         if not os.path.isdir(MMSEQS_outdir):
             os.makedirs(MMSEQS_outdir, exist_ok=True)
         subprocess.call(['wget', '--directory-prefix=' + str(MMSEQS_outdir), 
@@ -104,7 +106,7 @@ def get_ct3_dbs():
         if not is_tool("mmseqs") :
             print("mmseqs is not found. Exiting. Is conda environment activated?")
             sys.exit()
-        MMSEQS_outdir = os.path.join(str(args.C_DBS), "mmseqs_DBs")
+
         if not os.path.isdir(MMSEQS_outdir):
             os.makedirs(MMSEQS_outdir, exist_ok=True)
         subprocess.call(['wget', '--directory-prefix=' + str(MMSEQS_outdir), 
@@ -122,7 +124,7 @@ def get_ct3_dbs():
     if str(args.MMSEQS_CDD) == "True":
         # https://zenodo.org/records/10840546/files/cddid_all.tbl
         print ("running mmseqs CDD database update/install")
-        MMSEQS_outdir = os.path.join(str(args.C_DBS), "mmseqs_DBs")
+
         subprocess.call(['wget', '--directory-prefix=' + str(MMSEQS_outdir), 
                         'https://zenodo.org/records/10840546/files/cddid_all.tbl'])
         if not is_tool("mmseqs") :

--- a/src/cenote/python_modules/hhpred_to_table.py
+++ b/src/cenote/python_modules/hhpred_to_table.py
@@ -28,7 +28,7 @@ for hhresult_file in hhrout_list:
         with open(hhresult_file, 'r') as hrh:
             for line in hrh:
                 if line.startswith('Query         '):
-                    gene_name = line[15:].split(' ')[0]
+                    gene_name = line[14:].split(' ')[0]
                 
                 #with this logic, only files with results (lines starting with >) append the df
                 if line.startswith('>'):

--- a/src/cenote/python_modules/hhpred_to_table.py
+++ b/src/cenote/python_modules/hhpred_to_table.py
@@ -28,7 +28,7 @@ for hhresult_file in hhrout_list:
         with open(hhresult_file, 'r') as hrh:
             for line in hrh:
                 if line.startswith('Query         '):
-                    gene_name = line.strip('Query         ').split(' ')[0]
+                    gene_name = line[15:].split(' ')[0]
                 
                 #with this logic, only files with results (lines starting with >) append the df
                 if line.startswith('>'):
@@ -68,6 +68,7 @@ for hhresult_file in hhrout_list:
                             annotation = 'hypothetical protein'
 
                     full_stats = next(hrh, '').strip()
+                    
                     probability = full_stats.split('  ')[0].split('=')[1]
                     evalue = full_stats.split('  ')[1].split('=')[1]
                     Aligned_cols = full_stats.split('  ')[3].split('=')[1]

--- a/src/cenote/python_modules/terminal_repeats.py
+++ b/src/cenote/python_modules/terminal_repeats.py
@@ -81,7 +81,7 @@ terminal_r_list = []
 for seq_record in SeqIO.parse(fasta_file, "fasta"):
     dtr_seq = fetch_dtr(str(seq_record.seq))
 
-    if not dtr_seq or len(seq_record) > int(maxlength):
+    if not dtr_seq or len(seq_record) > float(maxlength):
         dtr_seq = "NA"
 
     itr_seq = fetch_itr(str(seq_record.seq))

--- a/src/cenote/python_modules/terminal_repeats.py
+++ b/src/cenote/python_modules/terminal_repeats.py
@@ -24,6 +24,8 @@ out_dir = sys.argv[7]
 
 wrap = sys.argv[8]
 
+maxlength = sys.argv[9]
+
 
 if not os.path.isdir(out_dir):
     os.makedirs(out_dir)
@@ -79,7 +81,7 @@ terminal_r_list = []
 for seq_record in SeqIO.parse(fasta_file, "fasta"):
     dtr_seq = fetch_dtr(str(seq_record.seq))
 
-    if not dtr_seq:
+    if not dtr_seq or len(seq_record) > int(maxlength):
         dtr_seq = "NA"
 
     itr_seq = fetch_itr(str(seq_record.seq))


### PR DESCRIPTION
Changes from `v3.3.0`:

1. Added argument `--max_dtr_assess`. Users can enter a maximum contig length to evaluate DTRs (default 1000000). Practically, long DTR-containing contigs are probably bacterial chromosomes and should be evaluated for prophages and pruned. Since DTR-containing contigs do not get pruned, this was preventing some bacterial chromosome assemblies from getting pruning treatment. https://github.com/mtisza1/Cenote-Taker3/issues/6
2. Fixed `hhpred_to_table.py` gene_name variable parsing, which previously incorrectly used .strip() function.
3. Fixed location of `MMSEQS_outdir` in `get_ct3_dbs` command to avoid error.
4. For read-mapping, `--seqtech` now effects `minimap2` settings
