### PR TITLE
fixing pyhmmer syntax, re.sub syntax

### DIFF
--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -13,6 +13,7 @@ import string
 import re
 import logging
 from shutil import which
+import pyhmmer
 
 def str2bool(v):
     if isinstance(v, bool):
@@ -64,7 +65,7 @@ def art_for_arts_sake():
         f"{rand_color[1]}^^^^^",f"{rand_color[0]}00000{ENDC}")
     print(f"{rand_color[0]}00000",f"{rand_color[1]}^^^^^",f"{rand_color[2]}TAKER!",
         f"{rand_color[1]}^^^^^",f"{rand_color[0]}00000{ENDC}")
-    print(f"{rand_color[0]}000000",f"{rand_color[1]}^^^^^^^^^^^^^^^^",f"{rand_color[0]}000000{ENDC}")
+    print(f"{rand_color[0]}00000",f"{rand_color[1]}^^^^^^^^^^^^^^^^^^",f"{rand_color[0]}00000{ENDC}")
     print(f"{rand_color[0]}0000000",f"{rand_color[1]}^^^^^^^^^^^^^^",f"{rand_color[0]}0000000{ENDC}")
     print(f"{rand_color[0]}0000000000",f"{rand_color[1]}^^^^^^^^",f"{rand_color[0]}0000000000{ENDC}")
     print(f"{rand_color[0]}000000000000000000000000000000{ENDC}")
@@ -79,7 +80,7 @@ def cenotetaker3():
 
     parentpath = Path(pathname).parents[1]
 
-    __version__ = "3.3.2"
+    __version__ = "3.4.0"
 
     Def_CPUs = os.cpu_count()
 
@@ -408,6 +409,14 @@ def cenotetaker3():
         if not 'pyrodigal_gv' in installed_packages:
             logger.warning(f"pyrodigal-gv not found in installed python packages. Exiting.")
             sys.exit() 
+    
+    # check pyhmmer version
+    if int(pyhmmer.__version__.split(".")[0]) == 0:
+        if int(pyhmmer.__version__.split(".")[1]) < 11:
+            logger.warning(f"pyhmmer version must be >= 0.11.0.")
+            logger.warning(f"Try: mamba install bioconda::pyhmmer=0.11.0")
+            logger.warning(f"Your version is {pyhmmer.__version__}. Exiting.")
+            sys.exit()
 
     ## check run_title suitability
     if re.search(r'^[a-zA-Z0-9_]+$', str(args.run_title)) and \

--- a/src/cenote/python_modules/make_sequin_tbls.py
+++ b/src/cenote/python_modules/make_sequin_tbls.py
@@ -230,7 +230,7 @@ for name, seq_group in chunk_grouped_df:
         elif row['Evidence_source'] == "mmseqs_cdd":  #mmseqs_cdd
             typeq = "CDS"            
             tagstr = ("protein_id" + "\tlcl|" + row['gene_name'])
-            productstr = re.sub("\..*", "", row['evidence_description'])
+            productstr = re.sub(r'\..*', "", row['evidence_description'], count = 1)
             inferencestr = ("inference\tprotein motif CDD:" + str(row['evidence_acession']))
             gtf_inf = ("protein motif " + str(row['evidence_acession']))
 

--- a/src/cenote/python_modules/pyhmmer_runner.py
+++ b/src/cenote/python_modules/pyhmmer_runner.py
@@ -62,7 +62,7 @@ hmmscan_list = []
 with multiprocessing.pool.ThreadPool(int(CPUcount)) as pool:
     for alignments in pool.map(hmmscanner, splitAA_list):
         for model in alignments:
-            quer1 = model.query_name.decode()
+            quer1 = model.query.name.decode()
             pos = quer1.rfind("_")
             contig = quer1[:pos]
             for hit in model:


### PR DESCRIPTION
bumping to version `3.4.0`

1. pyhmmer has updated its syntax starting with its `v0.11` release to use `query.name` instead of `query_name`. Therefore, `src/cenote/python_modules/pyhmmer_runner.py` has been updated to avoid this error.
2. forcing pyhmmer `v0.11.0` or higher in main script.
3. fixed `re.sub()` warning in `src/cenote/python_modules/make_sequin_tbls.py`