### PR TITLE
Update7: add `--circ-files` and fix zenodo DL. To v3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Image of example genome map:
 
 **Most recent versions**
 
-Cenote-Taker 3 scripts:   `v3.4.0`
+Cenote-Taker 3 scripts:   `v3.4.1`
 Cenote-Taker 3 Databases: `v3.1.1`
 
 **This should work on MacOS and Linux**

--- a/README.md
+++ b/README.md
@@ -71,12 +71,13 @@ Cenote-Taker 3 Databases: `v3.1.1`
 1) Use `mamba` to install the bioconda package
 
 **macOS** (specify `osx-64` platform regardless of which chip you have)
+*I'm also noticing a macOS-specific issue with newer `mmseqs` versions, so use `mmseqs2=15.6f452`*
 
-`mamba create --platform osx-64 -n ct3_env -c conda-forge -c bioconda cenote-taker3=3.4.0`
+`mamba create --platform osx-64 -n ct3_env -c conda-forge -c bioconda cenote-taker3=3.4.1 mmseqs2=15.6f452`
 
 **linux**
 
-`mamba create -n ct3_env -c conda-forge -c bioconda cenote-taker3=3.4.0`
+`mamba create -n ct3_env -c conda-forge -c bioconda cenote-taker3=3.4.1`
 
 <details>
 
@@ -84,11 +85,11 @@ Cenote-Taker 3 Databases: `v3.1.1`
 
   **macOS** (specify `osx-64` platform regardless of which chip you have)
 
-  `conda create --platform osx-64 -n ct3_env -c conda-forge -c bioconda cenote-taker3=3.4.0`
+  `conda create --platform osx-64 -n ct3_env -c conda-forge -c bioconda cenote-taker3=3.4.1 mmseqs2=15.6f452`
 
   **linux**
 
-  `conda create -n ct3_env -c conda-forge -c bioconda cenote-taker3=3.4.0`
+  `conda create -n ct3_env -c conda-forge -c bioconda cenote-taker3=3.4.1`
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cenotetaker3"
-version = "3.3.2"
+version = "3.4.1"
 authors = [
   { name="Mike Tisza", email="michael.tisza@gmail.com" },
 ]

--- a/src/cenote/cenote_main.sh
+++ b/src/cenote/cenote_main.sh
@@ -36,6 +36,7 @@ GENBANK=${31}
 TAXDBV=${32}
 SEQTECH=${33}
 MAX_LENGTH_DTR=${34}
+CIRCF=${35}
 
 ### check output directory (created in cenotetaker3.py)
 
@@ -153,6 +154,7 @@ echo "HHsuite tool:                      $HHSUITE_TOOL" >> ${C_OUTDIR}/run_argum
 echo "Taxonomy DB:                       $TAXDBV" >> ${C_OUTDIR}/run_arguments.txt
 echo "Sequencing Technology:             $SEQTECH" >> ${C_OUTDIR}/run_arguments.txt
 echo "Max seq length to assess DTRs:     $MAX_LENGTH_DTR" >> ${C_OUTDIR}/run_arguments.txt
+echo "File with circular contig IDs:     $CIRCF" >> ${C_OUTDIR}/run_arguments.txt
 
 
 
@@ -329,7 +331,7 @@ if [ -s ${TEMP_DIR}/unprocessed_hallmark_contigs.fasta ] ; then
 
 	python ${CENOTE_SCRIPTS}/python_modules/terminal_repeats.py ${TEMP_DIR}/unprocessed_hallmark_contigs.fasta\
 	${TEMP_DIR}/hallmarks_per_orig_contigs.tsv $circ_length_cutoff $linear_length_cutoff $CIRC_MINIMUM_DOMAINS\
-	$LIN_MINIMUM_DOMAINS ${TEMP_DIR} $WRAP $MAX_LENGTH_DTR
+	$LIN_MINIMUM_DOMAINS ${TEMP_DIR} $WRAP $MAX_LENGTH_DTR $CIRCF
 
 	if [ -s ${TEMP_DIR}/trimmed_TRs_hallmark_contigs.fasta ] && [ -s ${TEMP_DIR}/contigs_over_threshold.txt ] ; then
 		

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -80,7 +80,7 @@ def cenotetaker3():
 
     parentpath = Path(pathname).parents[1]
 
-    __version__ = "3.4.0"
+    __version__ = "3.4.1"
 
     Def_CPUs = os.cpu_count()
 

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -151,13 +151,6 @@ def cenotetaker3():
                                 considered viral and recieve full annotation. For samples physically enriched for virus \
                                 particles, \'0\' can be used, but please treat circular contigs without known viral \
                                 domains cautiously. For unenriched samples, \'1\' might be more suitable. ')
-    #optional_args.add_argument("--known_strains", dest="handle_knowns", type=str, default='do_not_check_knowns', help='Default: do_not_check_knowns -- do not check if putatively viral contigs are highly related to known sequences (via MEGABLAST). \'blast_knowns\': REQUIRES \'--blastn_db\' option to function correctly. ')
-    #optional_args.add_argument("--blastn_db", dest="BLASTN_DB", type=str, default='none', help='Default: none -- Set a database if using \'--known_strains\' option. Specify BLAST-formatted nucleotide datase. Probably, use only GenBank \'nt\' database, \'nt viral\', or a subset therof, downloaded from ftp://ftp.ncbi.nlm.nih.gov/ Headers must be GenBank record format')
-    #optional_args.add_argument("--enforce_start_codon", dest="ENFORCE_START_CODON", type=str2bool, default=False, 
-    #                        help='Default: False -- For final genome maps, require ORFs to be initiated by a typical \
-    #                            start codon? GenBank submissions containing ORFs without start codons can be rejected. \
-    #                            However, if True,  important but incomplete genes could be culled from the final output. \
-    #                            This is relevant mainly to contigs of incomplete genomes ')
     optional_args.add_argument("-hh", "--hhsuite_tool", dest="HHSUITE_TOOL", type=str, 
                                choices=['none', 'hhblits', 'hhsearch'], default='none', 
                             help=' default: none -- hhblits: query any of PDB, pfam, and CDD (depending on what is installed)\
@@ -167,7 +160,6 @@ def cenotetaker3():
                                 (WARNING: hhsearch takes much, much longer than hhblits and can extend the duration of the \
                                 run many times over. Do not use on large input contig files). \'none\': forgoes \
                                 annotation of ORFs with hhsuite. Fastest way to complete a run. ')
-
     optional_args.add_argument("--caller", dest="CALLER", type=str, choices=['prodigal-gv', 'prodigal', 'phanotate', 'adaptive'],
                             default='prodigal-gv', 
                             help=' ORF caller for viruses. default: prodigal-gv\
@@ -176,10 +168,6 @@ def cenotetaker3():
                                 Note: phanotate takes longer than prodigal, exponentially so for LONG input contigs.\
                                 adaptive: will choose based on preliminary taxonomy call \
                                 (phages = phanotate, others = prodigal-gv)')
-
-    ## should be host prediction, instead
-    #optional_args.add_argument("--crispr_file", dest="CRISPR_FILE", type=str, default='none', help='Tab-separated file with CRISPR hits in the following format: CONTIG_NAME HOST_NAME NUMBER_OF_MATCHES. You could use this tool: https://github.com/edzuf/CrisprOpenDB. Then reformat for Cenote-Taker 3')
-
     optional_args.add_argument("--isolation_source", dest="isolation_source", type=str, default='unknown', 
                             help='Default: unknown -- Describes the local geographical source of the organism from \
                                 which the sequence was derived')
@@ -208,16 +196,6 @@ def cenotetaker3():
                             help=' default: original -- original data is not taken from other researchers\' public or \
                                 private database. \'tpa_assembly\': data is taken from other researchers\' public or \
                                 private database. Please be sure to specify SRA metadata.  ')
-
-    ### I need to account for this or remove it:
-    optional_args.add_argument("--filter_out_plasmids", dest="FILTER_PLASMIDS", type=str2bool, default=True, 
-                            help=argparse.SUPPRESS)
-    ### I need to account for this or remove it:
-    #optional_args.add_argument("--scratch_directory", dest="SCRATCH_DIR", type=str, default="none", 
-    #                        help='Default: none -- When running many instances of Cenote-Taker 3, it seems to run more \
-    #                            quickly if you copy the hhsuite databases to a scratch space temporarily. Use this argument \
-    #                            to set a scratch directory that the databases will be copied to (at least 100GB of scratch \
-    #                            space are required for copying the databases)')
     optional_args.add_argument("--cenote-dbs", dest="C_DBS", type=str, default="default", 
                             help='DB path. If not set here, Cenote-Taker looks for environmental variable CENOTE_DBS. \
                                 Then, if this variable is unset, DB path is assumed to be ' + str(parentpath))
@@ -241,6 +219,13 @@ def cenotetaker3():
                             default=1_000_000, 
                             help='Default: 1000000 -- maximum sequence length to assess DTRs. Extra long \
                                 contigs with DTRs are likely to be bacterial chromosomes, not virus genomes.')
+    optional_args.add_argument("--circ-file", dest="circf", type=str,
+                            default="not given", 
+                            help='Provide a file with the IDs of contigs you believe are circular, one per line. \
+                                If using this option, CT3 will treat these contigs as circular but will \
+                                not search for DTRs in sequences. Useful for long read assembly outputs \
+                                (flye, myloasm) that report circular contigs.\
+                                --max_dtr_assess will still be considered.')
 
     
     args = parser.parse_args()
@@ -446,7 +431,7 @@ def cenotetaker3():
                     str(args.srr_number), str(args.srx_number), str(args.biosample), 
                     str(args.bioproject), str(args.ASSEMBLER), str(args.MOLECULE_TYPE), 
                     str(args.DATA_SOURCE), str(args.GENBANK), str(TAXDBV), str(args.SEQTECH),
-                    str(args.MAXDTR)],
+                    str(args.MAXDTR), str(args.circf)],
                     stdout=PIPE, stderr=STDOUT)
 
     with process.stdout:

--- a/src/cenote/cenotetaker3.py
+++ b/src/cenote/cenotetaker3.py
@@ -221,8 +221,9 @@ def cenotetaker3():
                                 contigs with DTRs are likely to be bacterial chromosomes, not virus genomes.')
     optional_args.add_argument("--circ-file", dest="circf", type=str,
                             default="not given", 
-                            help='Provide a file with the IDs of contigs you believe are circular, one per line. \
-                                If using this option, CT3 will treat these contigs as circular but will \
+                            help='Provide a file with the names of contigs (header line sans ">") \
+                                you believe are circular, one per line. \
+                                If using this option, CT3 will treat listed contigs as circular but will \
                                 not search for DTRs in sequences. Useful for long read assembly outputs \
                                 (flye, myloasm) that report circular contigs.\
                                 --max_dtr_assess will still be considered.')

--- a/src/cenote/get_ct3_databases.py
+++ b/src/cenote/get_ct3_databases.py
@@ -79,7 +79,7 @@ def get_ct3_dbs():
 
     if str(args.REFSEQ_TAX) == "True":
         # https://zenodo.org/records/10840546/files/refseq_virus_prot.fasta.gz
-        # https://zenodo.org/records/10840546/files/ct3_hallmark_nr_cd90_refseq.prot_taxids.mmseqs_fmt.tsv
+        # https://zenodo.org/records/10840546/files/refseq_virus_prot_taxids.mmseqs_fmt.tsv
         print ("running mmseqs refseq taxdb database update/install")
         if not is_tool("mmseqs") :
             print("mmseqs is not found. Exiting. Is conda environment activated?")
@@ -92,7 +92,7 @@ def get_ct3_dbs():
         subprocess.call(['gunzip', '-d', os.path.join(MMSEQS_outdir, 'refseq_virus_prot.fasta.gz')])
         #subprocess.call(['rm', '-f', os.path.join(MMSEQS_outdir, 'refseq_virus_prot.fasta.gz')])
         subprocess.call(['wget', '--directory-prefix=' + str(MMSEQS_outdir), 
-                        'https://zenodo.org/records/10840546/files/ct3_hallmark_nr_cd90_refseq.prot_taxids.mmseqs_fmt.tsv'])
+                        'https://zenodo.org/records/10840546/files/refseq_virus_prot_taxids.mmseqs_fmt.tsv'])
         subprocess.call(['mmseqs', 'createdb', os.path.join(MMSEQS_outdir, 'refseq_virus_prot.fasta'), 
                         os.path.join(MMSEQS_outdir, 'refseq_virus_prot_taxDB')])
         subprocess.call(['mmseqs', 'createtaxdb', os.path.join(MMSEQS_outdir, 'refseq_virus_prot_taxDB'), 

--- a/src/cenote/python_modules/terminal_repeats.py
+++ b/src/cenote/python_modules/terminal_repeats.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from ntpath import isfile
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -25,6 +26,8 @@ out_dir = sys.argv[7]
 wrap = sys.argv[8]
 
 maxlength = sys.argv[9]
+
+circf = sys.argv[10]
 
 
 if not os.path.isdir(out_dir):
@@ -74,12 +77,23 @@ def fetch_itr(seq, min_len=20, max_len=1000):
     else:
         return ""
 
-
+circ_ids = []
+if os.path.isfile(circf):
+    with open(circf, "r") as circs:
+        for line in circs:
+            circ_ids.append(line.strip())
 
 
 terminal_r_list = []
 for seq_record in SeqIO.parse(fasta_file, "fasta"):
-    dtr_seq = fetch_dtr(str(seq_record.seq))
+
+    if circ_ids:
+        if seq_record.description in circ_ids:
+            dtr_seq = "User-provided circular"
+        else:
+            dtr_seq = None
+    else:
+        dtr_seq = fetch_dtr(str(seq_record.seq))
 
     if not dtr_seq or len(seq_record) > float(maxlength):
         dtr_seq = "NA"
@@ -89,7 +103,7 @@ for seq_record in SeqIO.parse(fasta_file, "fasta"):
     if not itr_seq:
         itr_seq = "NA"
 
-    if not dtr_seq == "NA" and wrap.lower() == "true":
+    if not dtr_seq == "NA" and not dtr_seq == "User-provided circular" and wrap.lower() == "true":
         print(f">{seq_record.id}", file = open(output_allf, "a"))
         print(seq_record.seq[:-len(dtr_seq)], file = open(output_allf, "a"))
 

--- a/src/cenote/python_modules/terminal_repeats.py
+++ b/src/cenote/python_modules/terminal_repeats.py
@@ -83,12 +83,11 @@ if os.path.isfile(circf):
         for line in circs:
             circ_ids.append(line.strip())
 
-
 terminal_r_list = []
 for seq_record in SeqIO.parse(fasta_file, "fasta"):
-
+    fmt_desc = " ".join(seq_record.description.split(" ")[1:])
     if circ_ids:
-        if seq_record.description in circ_ids:
+        if fmt_desc in circ_ids:
             dtr_seq = "User-provided circular"
         else:
             dtr_seq = None

--- a/src/cenote/python_modules/virus_summary.py
+++ b/src/cenote/python_modules/virus_summary.py
@@ -160,7 +160,7 @@ for name, group in grouped_df:
     else:
         dtr_seqf = "None"
     
-    if all(c in "ATCG" for c in dtr_seqf):
+    if all(c in "ATCG" for c in dtr_seqf) or dtr_seqf == "User-provided circular":
         end_type = "DTR"
     else:
         end_type = "None"


### PR DESCRIPTION
Changes from v3.4.0 to v3.4.1 (minor version bump)

- Added `--circ-file` and associated code to allow users to pre-specify which input contigs are circular
- Fixed refseq table download 